### PR TITLE
Change memory limit description

### DIFF
--- a/project-zomboidconfig.json
+++ b/project-zomboidconfig.json
@@ -44,10 +44,10 @@
         }
     },
     {
-        "DisplayName": "Maximum Server Memory",
+        "DisplayName": "Memory Limit (MB)",
         "Category": "Server Settings",
-        "Description": "Maximum server memory (in MB)",
-        "Keywords": "maximum,memory",
+        "Description": "Java's maximum heap size",
+        "Keywords": "maximum,memory,limit",
         "FieldName": "MaxMemory",
         "InputType": "number",
         "IsFlagArgument": false,


### PR DESCRIPTION
Description now refers to maximum heap size for Java, like Minecraft module