### PR TITLE
Urgent fix: Add spaces to null Default Values

### DIFF
--- a/project-zomboidconfig.json
+++ b/project-zomboidconfig.json
@@ -65,7 +65,7 @@
         "IsFlagArgument": false,
         "ParamFieldName": "CustomJavaArgs",
         "IncludeInCommandLine": false,
-        "DefaultValue": ""
+        "DefaultValue": " "
     },
     {
         "DisplayName": "Additional Server Startup Parameters",
@@ -77,6 +77,6 @@
         "IsFlagArgument": false,
         "ParamFieldName": "CustomServerArgs",
         "IncludeInCommandLine": false,
-        "DefaultValue": ""
+        "DefaultValue": " "
     }
 ]


### PR DESCRIPTION
Add spaces to CustomJavaArgs and CustomServerArgs default values, to avoid the null default being populated literally with the FieldName