### PR TITLE
Project Zomboid: Allow Java GC algo selection on Windows

### DIFF
--- a/project-zomboid.kvp
+++ b/project-zomboid.kvp
@@ -18,7 +18,7 @@ App.ExecutableWin=380870\jre64\bin\java.exe
 App.ExecutableLinux=380870/ProjectZomboid64
 App.WorkingDir=380870
 App.LinuxCommandLineArgs=-Dzomboid.steam={{SteamInt}} -Duser.home=./ -Xmx{{MaxMemory}}m {{CustomJavaArgs}} --
-App.WindowsCommandLineArgs=-Djava.awt.headless=true -Dzomboid.znetlog=1 -Dzomboid.steam={{SteamInt}} -Duser.home=./ -Xmx{{MaxMemory}}m -XX:+UseZGC -XX:-CreateCoredumpOnCrash -XX:-OmitStackTraceInFastThrow -Djava.library.path=natives/;natives/win64/;. {{CustomJavaArgs}} -cp java/*;java/ zombie.network.GameServer -statistic 0 --
+App.WindowsCommandLineArgs=-Djava.awt.headless=true -Dzomboid.znetlog=1 -Dzomboid.steam={{SteamInt}} -Duser.home=./ -Xmx{{MaxMemory}}m {{JavaGCAlgo}} -XX:-CreateCoredumpOnCrash -XX:-OmitStackTraceInFastThrow -Djava.library.path=natives/;natives/win64/;. {{CustomJavaArgs}} -cp java/*;java/ zombie.network.GameServer -statistic 0 --
 App.CommandLineArgs={{$PlatformArgs}} -port {{$ApplicationPort1}} -steamport1 {{$ApplicationPort2}} -steamport2 {{$ApplicationPort3}} {{CustomServerArgs}} {{$FormattedArgs}}
 App.AppSettings={}
 App.EnvironmentVariables={"PATH":"./jre64/bin:%PATH%","LD_LIBRARY_PATH":"./linux64:./natives:./:./jre64/lib/amd64:%LD_LIBRARY_PATH%","LD_PRELOAD":"./jre64/lib/libjsig.so","PZ_CLASSPATH":"java/*;java/","SteamAppId":"108600"}

--- a/project-zomboidconfig.json
+++ b/project-zomboidconfig.json
@@ -56,6 +56,22 @@
         "DefaultValue": "4096"
     },
     {
+        "DisplayName": "Java Garbage Collection Algorithm (Windows)",
+        "Category": "Server Settings",
+        "Description": "Default Java garbage collection algorithm is ZGC, but G1GC can be selected for older Windows versions that cannot use ZGC",
+        "Keywords": "garbage,collection,algorithm",
+        "FieldName": "JavaGCAlgo",
+        "InputType": "enum",
+        "IsFlagArgument": false,
+        "ParamFieldName": "JavaGCAlgo",
+        "IncludeInCommandLine": false,
+        "DefaultValue": "-XX:+UseZGC",
+        "EnumValues": {
+            "-XX:+UseZGC": "ZGC Algorithm (default)",
+            "-XX:+UseG1GC": "G1GC Algorithm"
+        }
+    },
+    {
         "DisplayName": "Additional Java Startup Parameters",
         "Category": "Server Settings",
         "Description": "Additional Java arguments (not server arguments) as startup parameters that are not otherwise set by AMP. Use with care. Example: -Ddebug",


### PR DESCRIPTION
Older Windows versions cannot use the ZGC Java garbage collection algorithm. This option allows G1GC to be selected instead