### PR TITLE
Correct Stationeers Config

### DIFF
--- a/stationeers.kvp
+++ b/stationeers.kvp
@@ -22,10 +22,10 @@ App.ExecutableLinux=600760/rocketstation_DedicatedServer.x86_64
 App.WorkingDir=600760
 App.LinuxCommandLineArgs=
 App.WindowsCommandLineArgs=
-App.CommandLineArgs=-batchmode -nographics -autostart -bindip={{$ApplicationIPBinding}} -basedirectory="{{$FullBaseDir}}"  -modpath="{{$FullBaseDir}}{{modpath}}/" {{$FormattedArgs}}
+App.CommandLineArgs=-batchmode -nographics -autostart -bindip={{$ApplicationIPBinding}} {{$FormattedArgs}}
 App.AppSettings={}
 App.EnvironmentVariables={"LD_LIBRARY_PATH":"{{$FullBaseDir}}linux64:{{$FullRootDir}}linux64:%LD_LIBRARY_PATH%","SteamAppId":"544550"}
-App.CommandLineParameterFormat=-{0}="{1}"
+App.CommandLineParameterFormat=-{0}={1}
 App.CommandLineParameterDelimiter= 
 App.ExitMethod=OS_CLOSE
 App.ExitTimeout=30

--- a/stationeersconfig.json
+++ b/stationeersconfig.json
@@ -82,11 +82,11 @@
         "DisplayName": "World Name",
         "Category": "Server Settings",
         "Description": "Name of the world directory to load.",
-        "Keywords": "world,name",
-        "FieldName": "worldname",
+        "Keywords": "load,world",
+        "FieldName": "loadworld",
         "InputType": "text",
         "IsFlagArgument": false,
-        "ParamFieldName": "worldname",
+        "ParamFieldName": "loadworld",
         "IncludeInCommandLine": true,
         "DefaultValue": "world",
         "EnumValues": {}
@@ -94,17 +94,16 @@
     {
         "DisplayName": "Map",
         "Category": "Server Settings",
-        "Description": "Default: Moon. Will overwrite actual map on server browser if you use rocket to travel beween maps!",
+        "Description": "Default: Moon. Will create a world of this type or display this world type in the server browser if loading a save.",
         "Keywords": "world,type",
         "FieldName": "worldtype",
         "InputType": "enum",
         "IsFlagArgument": false,
         "ParamFieldName": "worldtype",
         "IncludeInCommandLine": true,
-        "DefaultValue": "",
+        "DefaultValue": "Moon",
         "SkipIfEmpty": true,
         "EnumValues": {
-            "": "Default",
             "Europa2": "Europa2",
             "Loulan": "Loulan",
             "Mars": "Mars",
@@ -124,7 +123,7 @@
         "IsFlagArgument": false,
         "ParamFieldName": "autosaveinterval",
         "IncludeInCommandLine": true,
-        "DefaultValue": "60",
+        "DefaultValue": "300",
         "EnumValues": {},
         "Suffix": "sec"
     },
@@ -141,19 +140,6 @@
         "DefaultValue": "60",
         "EnumValues": {},
         "Suffix": "sec"
-    },
-    {
-        "DisplayName": "Mod Path",
-        "Category": "Server Settings",
-        "Description": "Where mods are located inside the datastore.",
-        "Keywords": "mod,path",
-        "FieldName": "modpath",
-        "InputType": "text",
-        "IsFlagArgument": false,
-        "ParamFieldName": "modpath",
-        "IncludeInCommandLine": false,
-        "DefaultValue": "Mods",
-        "EnumValues": {}
     },
     {
         "DisplayName": "GAMEPORT",


### PR DESCRIPTION
This game has many bugs still and the dedicated server does not function properly. It is unable to create a new world. You must create a singleplayer/multiplayer game and copy it into the save folder. The line "OriginWorldSaveLocation" must be removed from the world_meta.xml file when importing.

-Remove uneccessary -basedirectory launch arg
-Removed -modpath launch arg that does not work. It must be manually set in the default.ini file
-Removed "" around launch args
-Corrected -worldname to -loadworld
-Clarified Map select option
-Set autosaveinterval to default at 300 per the default in the game