### PR TITLE
Adjust Project Zomboid Regex Again

### DIFF
--- a/project-zomboid.kvp
+++ b/project-zomboid.kvp
@@ -51,9 +51,9 @@ App.TemplateMatchRegex={{(\$?[\w]+)}}
 Console.FilterMatchRegex=
 Console.FilterMatchReplacement=
 Console.ThrowawayMessageRegex=^(WARNING|ERROR): Shader.+$
-Console.AppReadyRegex=^LOG\s+: Network\s+, \d+> [\d,.\s]+> \*+ SERVER STARTED \*+$
-Console.UserJoinRegex=^LOG\s+: Network\s+, \d+> [\d,.\s]+> Connected new client (?<username>.+?) ID # (?<userid>.+?) and assigned DL port (?<userport>.+?)$
-Console.UserLeaveRegex=^LOG\s+: (Network|General)\s+, \d+> [\d,.\s]+> (Disconnected player "(?<username>.+?)" |\d+ znet: Disconnecting client #(?<userid>.+?) SteamID=)\d+$
+Console.AppReadyRegex=^LOG\s+: Network\s+, \d+>.*> \*+ SERVER STARTED \*+$
+Console.UserJoinRegex=^LOG\s+: Network\s+, \d+>.*> Connected new client (?<username>.+?) ID # (?<userid>.+?) and assigned DL port (?<userport>.+?)$
+Console.UserLeaveRegex=^LOG\s+: (Network|General)\s+, \d+>.*> (Disconnected player "(?<username>.+?)" |\d+ znet: Disconnecting client #(?<userid>.+?) SteamID=)\d+$
 Console.UserChatRegex=
 Console.UpdateAvailableRegex=
 Console.SuppressLogAtStart=False


### PR DESCRIPTION
There is an issue with the system parsing the character for a certain locale. Simplified the regex to find anything in that section as it's useless info anyways.