### PR TITLE
[PZ] Allow UTF-8 chars in server description/welcome message

### DIFF
--- a/project-zomboidconfig.json
+++ b/project-zomboidconfig.json
@@ -405,7 +405,7 @@
         "IsFlagArgument":false,
         "ParamFieldName":"CustomJavaArgs",
         "IncludeInCommandLine":false,
-        "DefaultValue":"",
+        "DefaultValue":"-Dfile.encoding=UTF-8",
         "Placeholder":"-Ddebug",
         "EnumValues":{}
     },


### PR DESCRIPTION
Add -Dfile.encoding=UTF-8 to avoid non-working spanish characters on PZ server description and welcome message