### PR TITLE
Update 7D2D Network Option

### DIFF
--- a/seven-days-to-dieconfig.json
+++ b/seven-days-to-dieconfig.json
@@ -133,7 +133,7 @@
         "IsFlagArgument":false,
         "ParamFieldName":"/ServerSettings/property[@name='ServerDisabledNetworkProtocols']/@value",
         "IncludeInCommandLine":false,
-        "DefaultValue":"SteamNetworking",
+        "DefaultValue":"",
         "EnumValues":{
             "": "None",
             "SteamNetworking": "SteamNetworking",


### PR DESCRIPTION
Sets the disabled network option to "None" by default instead of SteamNetworking, which is what the devs default to. This causes more headaches than it helps.