### PR TITLE
Create Mod dir on base game update.

### DIFF
--- a/seven-days-to-dieupdates.json
+++ b/seven-days-to-dieupdates.json
@@ -7,6 +7,12 @@
     "UpdateSourceVersion": "{{Stream}}"
   },
   {
+    "UpdateStageName":"Create Mod Directory",
+    "UpdateSourcePlatform":"All",
+    "UpdateSource":"CreateDirectory",
+    "UpdateSourceArgs":"{{$FullBaseDir}}Mods"
+  },
+  {
     "UpdateStageName": "Settings File Download",
     "UpdateSourcePlatform": "All",
     "UpdateSource": "FetchURL",


### PR DESCRIPTION
When the game is updated it will create the Mods dir if it is not present. 