### PR TITLE
Update TeamSpeak 3 License Path

### DIFF
--- a/teamspeak3config.json
+++ b/teamspeak3config.json
@@ -196,7 +196,7 @@
     },
     {
         "DisplayName": "License File Path",
-        "Description": "The physical path where your license file is located.",
+        "Description": "The physical path where your license file is located. You must replace the existing \"licensekey.dat\" file with the one provided after purchasing. This file can be found in File Manager inside the instance.",
         "Category": "Server Settings",
         "Keywords": "license,path",
         "FieldName": "licensepath",

--- a/teamspeak3config.json
+++ b/teamspeak3config.json
@@ -204,7 +204,7 @@
         "IsFlagArgument": false,
         "ParamFieldName": "licensepath",
         "IncludeInCommandLine": false,
-        "DefaultValue": "teamspeak3-server_win64/",
+        "DefaultValue": "",
         "EnumValues": {}
     },
     {

--- a/teamspeak3server.ini
+++ b/teamspeak3server.ini
@@ -1,7 +1,7 @@
 machine_id=
 default_voice_port=9987
 voice_ip=0.0.0.0
-licensepath=teamspeak3-server_win64/
+licensepath=
 filetransfer_port=30033
 filetransfer_ip=0.0.0.0
 query_port=10011


### PR DESCRIPTION
Small fix to adjust the default License Path value to be blank, matching the working directory.