### PR TITLE
Added Darkness Falls Mod

### DIFF
--- a/seven-days-to-dieconfig.json
+++ b/seven-days-to-dieconfig.json
@@ -193,6 +193,21 @@
         "EnumValues":{},
         "Suffix": "level"
     },{
+        "DisplayName":"Persistent Player Profiles",
+        "Category":"7d2d - Server Settings",
+        "Description":"Enable/Disable players joining with the same profile they last logged in with.",
+        "Keywords":"Profile,Persistent,Enabled",
+        "FieldName":"PersistentPlayerProfiles",
+        "InputType":"checkbox",
+        "IsFlagArgument":false,
+        "ParamFieldName":"/ServerSettings/property[@name='PersistentPlayerProfiles']/@value",
+        "IncludeInCommandLine":false,
+        "DefaultValue":"false",
+        "EnumValues":{
+            "False": "false",
+            "True": "true"
+        }
+    },{
         "DisplayName":"Control Panel Enabled",
         "Category":"7d2d - Server Settings",
         "Description":"Enable/Disable the web control panel.",
@@ -1258,7 +1273,7 @@
         "EnumValues":{},
         "Suffix": "zombies"
     },{
-        "DisplayName":"Death Penalty - Experimental Only",
+        "DisplayName":"Death Penalty",
         "Category":"7d2d - Undead Legacy Settings",
         "Description":"Sets what will be the consequences to your progression when you die in the game: No penalty - you will not get XP debt as well as no debuff, that lowers your Attributes. Beginner - near Death Trauma debuff Vanilla like experience. Moderate - same as beginner, but also with loss of random Action skills. Standard - same as moderate, but also you will respawn with partial health, food and water.",
         "Keywords":"Death,Penalty",
@@ -1275,7 +1290,7 @@
             "3": "Standard"
         }
     },{
-        "DisplayName":"POI Tier Loot Scale - Experimental Only",
+        "DisplayName":"POI Tier Loot Scale",
         "Category": "7d2d - Undead Legacy Settings",
         "Description":"Multiplier determining how important a POI Tier is when scaling Loot Stage. 0% - Disabled Default, 100% Vanilla Scaling. Acceptable values are integers from 0 to 100",
         "Keywords":"POI,Tier,Loot,Scale",

--- a/seven-days-to-dieconfig.json
+++ b/seven-days-to-dieconfig.json
@@ -193,21 +193,6 @@
         "EnumValues":{},
         "Suffix": "level"
     },{
-        "DisplayName":"Persistent Player Profiles",
-        "Category":"7d2d - Server Settings",
-        "Description":"Enable/Disable players joining with the same profile they last logged in with.",
-        "Keywords":"Profile,Persistent,Enabled",
-        "FieldName":"PersistentPlayerProfiles",
-        "InputType":"checkbox",
-        "IsFlagArgument":false,
-        "ParamFieldName":"/ServerSettings/property[@name='PersistentPlayerProfiles']/@value",
-        "IncludeInCommandLine":false,
-        "DefaultValue":"false",
-        "EnumValues":{
-            "False": "false",
-            "True": "true"
-        }
-    },{
         "DisplayName":"Control Panel Enabled",
         "Category":"7d2d - Server Settings",
         "Description":"Enable/Disable the web control panel.",
@@ -1168,6 +1153,21 @@
             "True": "true"
         }
     },{
+        "DisplayName":"Install Darkness Falls",
+        "Category":"SteamCMD and Updates",
+        "Description":"Auto-installs Darkness Falls when the server is updated.",
+        "Keywords":"install,DarknessFalls",
+        "FieldName":"DarknessFalls",
+        "InputType":"checkbox",
+        "IsFlagArgument":false,
+        "ParamFieldName":"DarknessFalls",
+        "IncludeInCommandLine":false,
+        "DefaultValue":"false",
+        "EnumValues":{
+            "False": "false",
+            "True": "true"
+        }
+    },{
         "DisplayName":"Please Read!",
         "Category":"7d2d - Undead Legacy Settings",
         "Description":"If you would like to install Undead Legacy you need to pick either the Stable or Experimental config under the \"SteamCMD and Updates\" section. This will then grab the appropriate Undead Legacy version when you click update.",
@@ -1258,7 +1258,7 @@
         "EnumValues":{},
         "Suffix": "zombies"
     },{
-        "DisplayName":"Death Penalty",
+        "DisplayName":"Death Penalty - Experimental Only",
         "Category":"7d2d - Undead Legacy Settings",
         "Description":"Sets what will be the consequences to your progression when you die in the game: No penalty - you will not get XP debt as well as no debuff, that lowers your Attributes. Beginner - near Death Trauma debuff Vanilla like experience. Moderate - same as beginner, but also with loss of random Action skills. Standard - same as moderate, but also you will respawn with partial health, food and water.",
         "Keywords":"Death,Penalty",
@@ -1275,7 +1275,7 @@
             "3": "Standard"
         }
     },{
-        "DisplayName":"POI Tier Loot Scale",
+        "DisplayName":"POI Tier Loot Scale - Experimental Only",
         "Category": "7d2d - Undead Legacy Settings",
         "Description":"Multiplier determining how important a POI Tier is when scaling Loot Stage. 0% - Disabled Default, 100% Vanilla Scaling. Acceptable values are integers from 0 to 100",
         "Keywords":"POI,Tier,Loot,Scale",

--- a/seven-days-to-dieconfig.json
+++ b/seven-days-to-dieconfig.json
@@ -1170,7 +1170,7 @@
     },{
         "DisplayName":"Install Darkness Falls",
         "Category":"SteamCMD and Updates",
-        "Description":"Auto-installs Darkness Falls when the server is updated.",
+        "Description":"Auto-installs Darkness Falls when the server is updated. This is the Stable branch.",
         "Keywords":"install,DarknessFalls",
         "FieldName":"DarknessFalls",
         "InputType":"checkbox",

--- a/seven-days-to-dieupdates.json
+++ b/seven-days-to-dieupdates.json
@@ -7,6 +7,12 @@
     "UpdateSourceVersion": "{{Stream}}"
   },
   {
+    "UpdateStageName":"Create Mod Directory",
+    "UpdateSourcePlatform":"All",
+    "UpdateSource":"CreateDirectory",
+    "UpdateSourceArgs":"{{$FullBaseDir}}Mods"
+  },
+  {
     "UpdateStageName": "Settings File Download",
     "UpdateSourcePlatform": "All",
     "UpdateSource": "FetchURL",

--- a/seven-days-to-dieupdates.json
+++ b/seven-days-to-dieupdates.json
@@ -7,12 +7,6 @@
     "UpdateSourceVersion": "{{Stream}}"
   },
   {
-    "UpdateStageName":"Create Mod Directory",
-    "UpdateSourcePlatform":"All",
-    "UpdateSource":"CreateDirectory",
-    "UpdateSourceArgs":"{{$FullBaseDir}}Mods"
-  },
-  {
     "UpdateStageName": "Settings File Download",
     "UpdateSourcePlatform": "All",
     "UpdateSource": "FetchURL",
@@ -159,5 +153,36 @@
     "UpdateSourceArgs": "-c \"cp -rf ./seven-days-to-die/294420/UndeadLegacyExperimental*/* ./seven-days-to-die/294420/ && rm -rf ./seven-days-to-die/294420/UndeadLegacyExperimental*/\"",
     "UpdateSourceConditionSetting": "ConfigFile",
     "UpdateSourceConditionValue": "seven-days-settings-undead-legacy-experimental"
+  },
+  {
+    "UpdateStageName":"Download Darkness Falls",
+    "UpdateSourcePlatform":"All",
+    "UpdateSource": "FetchURL",
+    "UpdateSourceData": "https://gitlab.com/KhaineGB/darkness-falls-a20/-/archive/main/darkness-falls-a20-main.zip",
+    "UpdateSourceArgs":"darkness-falls-a20-main.zip",
+    "UpdateSourceTarget":"{{$FullBaseDir}}",
+    "UnzipUpdateSource": true,
+    "OverwriteExistingFiles": true,
+    "UpdateSourceConditionSetting": "DarknessFalls",
+    "UpdateSourceConditionValue": "true",
+    "DeleteAfterExtract": true
+  },
+  {
+    "UpdateStageName": "Darkness Falls Copy",
+    "UpdateSourcePlatform": "Windows",
+    "UpdateSource": "Executable",
+    "UpdateSourceData": "cmd.exe",
+    "UpdateSourceArgs": "/C xcopy /E /Y /I seven-days-to-die\\294420\\darkness-falls-a20-main\\* seven-days-to-die\\294420\\ && rmdir /Q /S seven-days-to-die\\294420\\darkness-falls-a20-main",
+    "UpdateSourceConditionSetting": "DarknessFalls",
+    "UpdateSourceConditionValue": "true"
+  },
+  {
+    "UpdateStageName": "Darkness Falls Copy",
+    "UpdateSourcePlatform": "Linux",
+    "UpdateSource": "Executable",
+    "UpdateSourceData": "/bin/bash",
+    "UpdateSourceArgs": "-c \"cp -rf ./seven-days-to-die/294420/darkness-falls-a20-main/* ./seven-days-to-die/294420/ && rm -rf ./seven-days-to-die/294420/darkness-falls-a20-main*/\"",
+    "UpdateSourceConditionSetting": "DarknessFalls",
+    "UpdateSourceConditionValue": "true"
   }
 ]


### PR DESCRIPTION
Added Darkness Falls mod download toggle to the SteamCMD and Updates category as there are no extra config settings. 

Tested and working on both Linux and Windows.

seven-days-to-dieconfig.json
- Added the Darkness Falls toggle under SteamCMD and Updates category

seven-days-to-dieupdates.json
- Added the zip download from the Darkness Falls gitlab repo. 
- Added copy and delete command to pull the files from the unzipped folder to the root folder and delete it when its done for both Linux and Windows. 