### PR TITLE
Update Empyrion - Backup Exclude Toggle

### DIFF
--- a/empyrion-galactic-survivalconfig.json
+++ b/empyrion-galactic-survivalconfig.json
@@ -407,5 +407,21 @@
     "DefaultValue": "public",
     "Placeholder": "public",
     "EnumValues": {}
+  },
+  {
+    "DisplayName":"Download Backup Exclude File",
+    "Category":"SteamCMD and Updates",
+    "Description":"This downloads a default backup exclude file to save space on backups by only saving specific directories. If this is disabled, you will need to manually delete the .backupExclude file it downloads.",
+    "Keywords":"download,backup,exclude,file",
+    "FieldName":"backupExclude",
+    "InputType":"checkbox",
+    "IsFlagArgument":false,
+    "ParamFieldName":"backupExclude",
+    "IncludeInCommandLine":false,
+    "DefaultValue":"true",
+    "EnumValues":{
+        "False": "false",
+        "True": "true"
+    }
   }
 ]

--- a/empyrion-galactic-survivalupdates.json
+++ b/empyrion-galactic-survivalupdates.json
@@ -21,6 +21,8 @@
     "UpdateSourceData":"https://github.com/CubeCoders/AMPTemplates/raw/main/exclusions/.backupExclusionsEmpyrion1",
     "UpdateSourceArgs":".backupExclude",
     "UpdateSourceTarget":"{{$FullBaseDir}}",
+    "UpdateSourceConditionSetting": "backupExclude",
+    "UpdateSourceConditionValue": "true",
     "OverwriteExistingFiles":false
   }
 ]


### PR DESCRIPTION
This adds a checkbox slider to allow disabling the download of the default backup exclude file.