### PR TITLE
Just Cause 3 - Added quotes to the Host IP

### DIFF
--- a/jc3mpserverconfig.json
+++ b/jc3mpserverconfig.json
@@ -1,7 +1,7 @@
 {
   "announce": {{announce}},
   "description": "{{description}}",
-  "host": {{hostip}},
+  "host": "{{hostip}}",
   "httpPort": {{hport}},
   "logLevel": 7,
   "logo": "",


### PR DESCRIPTION
Added quotes to the host server config option as it started requiring them at some point in the past.