### PR TITLE
Valheim - Changed update soruce for BepInEx

### DIFF
--- a/valheimupdates.json
+++ b/valheimupdates.json
@@ -24,12 +24,30 @@
     "UpdateStageName": "Fetch BepInEx from Thunderstore",
     "UpdateSourcePlatform": "All",
     "UpdateSource": "FetchURL",
-    "UpdateSourceArgs": "https://valheim.thunderstore.io/package/download/denikson/BepInExPack_Valheim/5.4.1901/",
-    "UpdateSourceData": "denikson-BepInExPack_Valheim-5.4.1901.zip",
+    "UpdateSourceData": "https://valheim.thunderstore.io/package/download/denikson/BepInExPack_Valheim/5.4.1901/",
+    "UpdateSourceArgs": "denikson-BepInExPack_Valheim-5.4.1901.zip",
     "UpdateSourceConditionSetting": "bepinex_install",
     "UpdateSourceConditionValue": "true",
     "UnzipUpdateSource": true,
     "OverwriteExistingFiles": true
+  },
+  {
+    "UpdateStageName": "BepInEx Copy",
+    "UpdateSourcePlatform": "Windows",
+    "UpdateSource": "Executable",
+    "UpdateSourceData": "cmd.exe",
+    "UpdateSourceArgs": "/C move Valheim\\896660\\BepInExPack_Valheim Valheim\\896660\\UndeadLegacyStable && xcopy /E /Y /I Valheim\\896660\\BepInExPack_Valheim\\* Valheim\\896660\\ && rmdir /Q /S Valheim\\896660\\BepInExPack_Valheim",
+    "UpdateSourceConditionSetting": "bepinex_install",
+    "UpdateSourceConditionValue": "true"
+  },
+  {
+    "UpdateStageName": "BepInEx Copy",
+    "UpdateSourcePlatform": "Linux",
+    "UpdateSource": "Executable",
+    "UpdateSourceData": "/bin/bash",
+    "UpdateSourceArgs": "-c \"cp -rf ./Valheim/896660/BepInExPack_Valheim/* ./Valheim/896660/ && rm -rf ./Valheim/896660/BepInExPack_Valheim/\"",
+    "UpdateSourceConditionSetting": "bepinex_install",
+    "UpdateSourceConditionValue": "true"
   },
   {
     "UpdateStageName": "Fetch ValheimPlus from Github - Windows",

--- a/valheimupdates.json
+++ b/valheimupdates.json
@@ -37,7 +37,7 @@
     "UpdateSourcePlatform": "Windows",
     "UpdateSource": "Executable",
     "UpdateSourceData": "cmd.exe",
-    "UpdateSourceArgs": "/C move Valheim\\896660\\BepInExPack_Valheim Valheim\\896660\\UndeadLegacyStable && xcopy /E /Y /I Valheim\\896660\\BepInExPack_Valheim\\* Valheim\\896660\\ && rmdir /Q /S Valheim\\896660\\BepInExPack_Valheim",
+    "UpdateSourceArgs": "/C move Valheim\\896660\\BepInExPack_Valheim Valheim\\896660\\BepInExPack_Valheim && xcopy /E /Y /I Valheim\\896660\\BepInExPack_Valheim\\* Valheim\\896660\\ && rmdir /Q /S Valheim\\896660\\BepInExPack_Valheim",
     "UpdateSourceConditionSetting": "bepinex_install",
     "UpdateSourceConditionValue": "true"
   },

--- a/valheimupdates.json
+++ b/valheimupdates.json
@@ -37,7 +37,7 @@
     "UpdateSourcePlatform": "Windows",
     "UpdateSource": "Executable",
     "UpdateSourceData": "cmd.exe",
-    "UpdateSourceArgs": "/C move Valheim\\896660\\BepInExPack_Valheim Valheim\\896660\\BepInExPack_Valheim && xcopy /E /Y /I Valheim\\896660\\BepInExPack_Valheim\\* Valheim\\896660\\ && rmdir /Q /S Valheim\\896660\\BepInExPack_Valheim",
+    "UpdateSourceArgs": "/C xcopy /E /Y /I Valheim\\896660\\BepInExPack_Valheim\\* Valheim\\896660\\ && rmdir /Q /S Valheim\\896660\\BepInExPack_Valheim",
     "UpdateSourceConditionSetting": "bepinex_install",
     "UpdateSourceConditionValue": "true"
   },

--- a/valheimupdates.json
+++ b/valheimupdates.json
@@ -29,7 +29,8 @@
     "UpdateSourceConditionSetting": "bepinex_install",
     "UpdateSourceConditionValue": "true",
     "UnzipUpdateSource": true,
-    "OverwriteExistingFiles": true
+    "OverwriteExistingFiles": true,
+    "DeleteAfterExtract": true
   },
   {
     "UpdateStageName": "BepInEx Copy",

--- a/valheimupdates.json
+++ b/valheimupdates.json
@@ -21,22 +21,11 @@
     "UpdateSourceArgs": "-c \"mv {{$FullBaseDir}}/Data/ {{$FullBaseDir}}/Saves/\""
   },
   {
-    "UpdateStageName": "Fetch BepInEx from Github - Windows",
-    "UpdateSourcePlatform": "Windows",
-    "UpdateSource": "GithubRelease",
-    "UpdateSourceArgs": "BepInEx/BepInEx",
-    "UpdateSourceData": "BepInEx_x64_5.4.21.0.zip",
-    "UpdateSourceConditionSetting": "bepinex_install",
-    "UpdateSourceConditionValue": "true",
-    "UnzipUpdateSource": true,
-    "OverwriteExistingFiles": true
-  },
-  {
-    "UpdateStageName": "Fetch BepInEx from Github - Linux",
-    "UpdateSourcePlatform": "Linux",
-    "UpdateSource": "GithubRelease",
-    "UpdateSourceArgs": "BepInEx/BepInEx",
-    "UpdateSourceData": "BepInEx_unix_5.4.21.0.zip",
+    "UpdateStageName": "Fetch BepInEx from Thunderstore",
+    "UpdateSourcePlatform": "All",
+    "UpdateSource": "FetchURL",
+    "UpdateSourceArgs": "https://valheim.thunderstore.io/package/download/denikson/BepInExPack_Valheim/5.4.1901/",
+    "UpdateSourceData": "denikson-BepInExPack_Valheim-5.4.1901.zip",
     "UpdateSourceConditionSetting": "bepinex_install",
     "UpdateSourceConditionValue": "true",
     "UnzipUpdateSource": true,


### PR DESCRIPTION
Changed the BepInEx update source from the github to fetchURL from thunderstore.io
https://valheim.thunderstore.io/package/denikson/BepInExPack_Valheim/
