### PR TITLE
Updated ecoconfig.json

### DIFF
--- a/ecoconfig.json
+++ b/ecoconfig.json
@@ -133,7 +133,7 @@
         "FieldName":"$MaxUsers",
         "InputType":"number",
         "IsFlagArgument":false,
-        "ParamFieldName":"MaxConnections",
+        "ParamFieldName":"DefaultSlots",
         "IncludeInCommandLine":false,
         "DefaultValue":"-1",
         "Suffix":"players",


### PR DESCRIPTION
Changed MaxConnections to DefaultSlots - maxconnections was removed from the Network.eco setting, and replaced with MaxConnections