### PR TITLE
Update Valheim+ Metaconfig

### DIFF
--- a/valheimmetaconfig.json
+++ b/valheimmetaconfig.json
@@ -3,7 +3,14 @@
         "ConfigFile":"./BepInEx/config/valheim_plus.cfg", 
         "AutoMap":true,
         "ConfigType":"ini",
-        "ConfigFormat": "{0}={1}",
+        "ConfigFormat":"{0}={1}",
         "ConfigFormatRegex":"^(?<key>.+?)=(?<value>.*?)$"
+    },
+    {
+        "ConfigFile":"./BepInEx/config/valheim_plus.cfg", 
+        "AutoMap":true,
+        "ConfigType":"ini",
+        "ConfigFormat":"{0} = {1}",
+        "ConfigFormatRegex":"^(?<key>.+?) = (?<value>.*?)$"
     }
 ]


### PR DESCRIPTION
The Valheim+ server changes the ini file to contain spaces in the config file even though the initial config does not. This allows AMP to parse either format and update the file as needed. This requires 2.4.1.4 Nightly to work.