### PR TITLE
FVTT: update default Node.js version

### DIFF
--- a/foundry-vttconfig.json
+++ b/foundry-vttconfig.json
@@ -29,15 +29,15 @@
     {
         "DisplayName":"Node.js Version",
         "Category":"Server Settings",
-        "Description":"Sets the [Node.js release version](https://nodejs.org/download/release/) to install to run the server. Minimum v14.x required. NOTE: Specify a numbered version like v14.21.3, rather than any \"latest\" version",
+        "Description":"Sets the [Node.js release version](https://nodejs.org/download/release/) to install to run the server. Minimum v16.x required. NOTE: Specify a numbered version like v18.16.0, rather than any \"latest\" version",
         "Keywords":"node,nodejs,version",
         "FieldName":"NodeVersion",
         "InputType":"text",
         "IsFlagArgument":false,
         "ParamFieldName":"NodeVersion",
         "IncludeInCommandLine":false,
-        "DefaultValue":"v14.21.3",
-        "Placeholder":"v14.21.3",
+        "DefaultValue":"v18.16.0",
+        "Placeholder":"v18.16.0",
         "EnumValues":{}
     },
     {


### PR DESCRIPTION
The latest version of the server requires at least Node.js v16.x now. 18.16.0 is current LTS