### PR TITLE
Update 7D2D Default Config File

### DIFF
--- a/seven-days-to-dieconfig.json
+++ b/seven-days-to-dieconfig.json
@@ -1229,7 +1229,7 @@
         "IsFlagArgument":false,
         "ParamFieldName":"ConfigFile",
         "IncludeInCommandLine":false,
-        "DefaultValue":"seven-days-settings204",
+        "DefaultValue":"seven-days-settings210",
         "EnumValues":{
             "seven-days-settings184": "18.4",
             "seven-days-settings196": "19.6",


### PR DESCRIPTION
alpha 21 is the new public version. This is updating it to match.