### PR TITLE
Valheim: updates for latest server and BepInEx

### DIFF
--- a/valheim.kvp
+++ b/valheim.kvp
@@ -1,4 +1,4 @@
-﻿Meta.DisplayName=Valheim
+Meta.DisplayName=Valheim
 Meta.Description=Includes optional support for ValheimPlus and BepinEx
 Meta.OS=Windows, Linux
 Meta.Author=CubeCoders Limited
@@ -16,7 +16,7 @@ App.ExecutableWin=896660\valheim_server.exe
 App.ExecutableLinux=896660/valheim_server.x86_64
 App.WorkingDir=896660
 App.CommandLineArgs=-port {{$ApplicationPort1}} {{$FormattedArgs}} -savedir "Saves" {{crossplay}}
-App.EnvironmentVariables={"DOORSTOP_ENABLE":"TRUE","DOORSTOP_INVOKE_DLL_PATH":"{{$FullBaseDir}}BepInEx/core/BepInEx.Preloader.dll","DOORSTOP_CORLIB_OVERRIDE_PATH":"{{$FullBaseDir}}unstripped_corlib","LD_LIBRARY_PATH":"{{$FullBaseDir}}doorstop_libs:{{$FullRootDir}}linux64:%LD_LIBRARY_PATH%","LD_PRELOAD":"libdoorstop_x64.so","SteamAppId":"892970"}
+App.EnvironmentVariables={"DOORSTOP_ENABLE":"TRUE","DOORSTOP_INVOKE_DLL_PATH":"{{$FullBaseDir}}BepInEx/core/BepInEx.Preloader.dll","LD_LIBRARY_PATH":"{{$FullBaseDir}}doorstop_libs:{{$FullRootDir}}linux64:%LD_LIBRARY_PATH%","LD_PRELOAD":"libdoorstop_x64.so","SteamAppId":"892970"}
 App.CommandLineParameterFormat=-{0} "{1}"
 App.ExitMethod=OS_CLOSE
 App.HasWriteableConsole=False

--- a/valheimconfig.json
+++ b/valheimconfig.json
@@ -112,8 +112,8 @@
     "IsFlagArgument":false,
     "ParamFieldName":"bepinex_version",
     "IncludeInCommandLine":false,
-    "DefaultValue":"5.4.2200",
-    "Placeholder":"5.4.2200",
+    "DefaultValue":"5.4.2202",
+    "Placeholder":"5.4.2202",
     "EnumValues":{}
   },{
     "DisplayName":"Install Valheim Plus",

--- a/valheimupdates.json
+++ b/valheimupdates.json
@@ -22,36 +22,6 @@
     "UpdateSourceArgs": "-c \"mv {{$FullBaseDir}}/Data/ {{$FullBaseDir}}/Saves/\""
   },
   {
-    "UpdateStageName": "Fetch BepInEx from Thunderstore",
-    "UpdateSourcePlatform": "All",
-    "UpdateSource": "FetchURL",
-    "UpdateSourceData": "https://valheim.thunderstore.io/package/download/denikson/BepInExPack_Valheim/{{bepinex_version}}/",
-    "UpdateSourceArgs": "denikson-BepInExPack_Valheim-{{bepinex_version}}.zip",
-    "UpdateSourceConditionSetting": "bepinex_install",
-    "UpdateSourceConditionValue": "true",
-    "UnzipUpdateSource": true,
-    "OverwriteExistingFiles": true,
-    "DeleteAfterExtract": true
-  },
-  {
-    "UpdateStageName": "BepInEx Copy",
-    "UpdateSourcePlatform": "Windows",
-    "UpdateSource": "Executable",
-    "UpdateSourceData": "cmd.exe",
-    "UpdateSourceArgs": "/C xcopy /E /Y /I Valheim\\896660\\BepInExPack_Valheim\\* Valheim\\896660\\ && rmdir /Q /S Valheim\\896660\\BepInExPack_Valheim",
-    "UpdateSourceConditionSetting": "bepinex_install",
-    "UpdateSourceConditionValue": "true"
-  },
-  {
-    "UpdateStageName": "BepInEx Copy",
-    "UpdateSourcePlatform": "Linux",
-    "UpdateSource": "Executable",
-    "UpdateSourceData": "/bin/bash",
-    "UpdateSourceArgs": "-c \"cp -rf ./Valheim/896660/BepInExPack_Valheim/* ./Valheim/896660/ && rm -rf ./Valheim/896660/BepInExPack_Valheim/\"",
-    "UpdateSourceConditionSetting": "bepinex_install",
-    "UpdateSourceConditionValue": "true"
-  },
-  {
     "UpdateStageName": "Fetch ValheimPlus from Github - Windows",
     "UpdateSourcePlatform": "Windows",
     "UpdateSource": "GithubRelease",
@@ -82,6 +52,36 @@
     "UpdateSourceTarget": "{{$FullBaseDir}}/BepInEx/config",
     "OverwriteExistingFiles": false,
     "UpdateSourceConditionSetting": "valheim_plus_install",
+    "UpdateSourceConditionValue": "true"
+  },
+  {
+    "UpdateStageName": "Fetch BepInEx from Thunderstore",
+    "UpdateSourcePlatform": "All",
+    "UpdateSource": "FetchURL",
+    "UpdateSourceData": "https://valheim.thunderstore.io/package/download/denikson/BepInExPack_Valheim/{{bepinex_version}}/",
+    "UpdateSourceArgs": "denikson-BepInExPack_Valheim-{{bepinex_version}}.zip",
+    "UpdateSourceConditionSetting": "bepinex_install",
+    "UpdateSourceConditionValue": "true",
+    "UnzipUpdateSource": true,
+    "OverwriteExistingFiles": true,
+    "DeleteAfterExtract": true
+  },
+  {
+    "UpdateStageName": "BepInEx Copy",
+    "UpdateSourcePlatform": "Windows",
+    "UpdateSource": "Executable",
+    "UpdateSourceData": "cmd.exe",
+    "UpdateSourceArgs": "/C xcopy /E /Y /I Valheim\\896660\\BepInExPack_Valheim\\* Valheim\\896660\\ && rmdir /Q /S Valheim\\896660\\BepInExPack_Valheim",
+    "UpdateSourceConditionSetting": "bepinex_install",
+    "UpdateSourceConditionValue": "true"
+  },
+  {
+    "UpdateStageName": "BepInEx Copy",
+    "UpdateSourcePlatform": "Linux",
+    "UpdateSource": "Executable",
+    "UpdateSourceData": "/bin/bash",
+    "UpdateSourceArgs": "-c \"cp -rf ./Valheim/896660/BepInExPack_Valheim/* ./Valheim/896660/ && rm -rf ./Valheim/896660/BepInExPack_Valheim/\"",
+    "UpdateSourceConditionSetting": "bepinex_install",
     "UpdateSourceConditionValue": "true"
   }
 ]


### PR DESCRIPTION
Also re-order update stages to allow standalone Bep to be installed over V+ in cases of V+ not being updated to include the latest Bep