### PR TITLE
Longvinter: improve GitHub repo updating

### DIFF
--- a/longvinterupdates.json
+++ b/longvinterupdates.json
@@ -14,6 +14,13 @@
         "UpdateSourceTarget":"{{$FullBaseDir}}"
     },
     {
+        "UpdateStageName":"Update GitHub Repo",
+        "UpdateSourcePlatform":"Linux",
+        "UpdateSource":"Executable",
+        "UpdateSourceData":"/bin/bash",
+        "UpdateSourceArgs":"-c \"cd {{$FullBaseDir}} && git restore . && git pull https://github.com/Uuvana-Studios/longvinter-linux-server.git\""
+    },
+    {
         "UpdateStageName":"Set Binary Executable Flag",
         "UpdateSourcePlatform":"Linux",
         "UpdateSource":"SetExecutableFlag",


### PR DESCRIPTION
Running just `git pull`, as AMP's GitRepo update stage does, doesn't cut it