### PR TITLE
Update post-scriptummetaconfig.json

### DIFF
--- a/post-scriptummetaconfig.json
+++ b/post-scriptummetaconfig.json
@@ -3,6 +3,6 @@
       "ConfigFile": "./PostScriptum/ServerConfig/Server.cfg",
       "AutoMap": true,
       "ConfigType": "kvp",
-      "ConfigFormat": "{0}=\"{1}\""
+      "ConfigFormat": "{0}={1}"
     }
 ]


### PR DESCRIPTION
Remove quotation marks in metaconfig due to incompatibility with MapVoting configuration