### PR TITLE
BeamMP: Update Source Fix

### DIFF
--- a/beammpconfig.json
+++ b/beammpconfig.json
@@ -2,7 +2,7 @@
     {
         "DisplayName":"Linux Server Version",
         "Category":"BeamMP - Server Settings",
-        "Description":"Sets the server version to install on Linux, based on the host system. Use \"Ubuntu 22.04\" if using AMP's Docker. NOTE: Update the server after changing this setting",
+        "Description":"Sets the server version to install on Linux, based on the host system. Use \"Ubuntu 22.04/Debian 12\" if using AMP's Docker. NOTE: Update the server after changing this setting",
         "Keywords":"server,version",
         "FieldName":"ServerVersion",
         "InputType":"enum",
@@ -11,7 +11,7 @@
         "IncludeInCommandLine":false,
         "DefaultValue":"ubuntu",
         "EnumValues":{
-            "ubuntu":"Ubuntu 22.04 (Default)",
+            "ubuntu":"Ubuntu 22.04/Debian 12 (default)",
             "debian":"Debian 11"
         }
     },

--- a/beammpconfig.json
+++ b/beammpconfig.json
@@ -11,8 +11,8 @@
         "IncludeInCommandLine":false,
         "DefaultValue":"ubuntu",
         "EnumValues":{
-            "ubuntu":"Ubuntu 22.04 (Default)"
-            "debian":"Debian 11",
+            "ubuntu":"Ubuntu 22.04 (Default)",
+            "debian":"Debian 11"
         }
     },
     {

--- a/beammpconfig.json
+++ b/beammpconfig.json
@@ -2,19 +2,17 @@
     {
         "DisplayName":"Linux Server Version",
         "Category":"BeamMP - Server Settings",
-        "Description":"Sets the server version to install on Linux, based on the host system. Use \"Ubuntu 22.04/Debian 12\" if using AMP's Docker. NOTE: Update the server after changing this setting",
+        "Description":"Sets the server version to install on Linux, based on the host system. Use \"Ubuntu 22.04\" if using AMP's Docker. NOTE: Update the server after changing this setting",
         "Keywords":"server,version",
         "FieldName":"ServerVersion",
         "InputType":"enum",
         "IsFlagArgument":false,
         "ParamFieldName":"ServerVersion",
         "IncludeInCommandLine":false,
-        "DefaultValue":"linux",
+        "DefaultValue":"ubuntu",
         "EnumValues":{
-            "linux":"Ubuntu 22.04/Debian 12 (default)",
-            "ubuntu-20.04":"Ubuntu 20.04",
-            "debian-11":"Debian 11",
-            "archlinux":"Arch Linux"
+            "ubuntu":"Ubuntu 22.04 (Default)"
+            "debian":"Debian 11",
         }
     },
     {


### PR DESCRIPTION
It appears the last few BeamMP releases are using different file names, leading to the server files failing to download.

I've removed "linux" and "archlinux" which seem to no longer be in use.
Changed the new defuault to the "ubuntu" build, which is Ubuntu 22.04 and made this the default based on the description mentioning this build was recommended for AMP's Debian 12 container. Updated the description to match.
Debian 11 build remains available under "debian"

Based on the one user I was helping test this, updating this may require existing users updating their config to work around the list bug, changign the dropdown then changing it back, due to removal of the old value. If there's a better way to handle that go right ahead :)