### PR TITLE
Valheim: Add save interval parameter

### DIFF
--- a/valheimconfig.json
+++ b/valheimconfig.json
@@ -267,6 +267,20 @@
     "Special": "listfile:./Valheim/896660/Saves/bannedlist.txt"
   },
   {
+    "DisplayName": "World Save Interval",
+    "Category": "Valheim - General Settings",
+    "Description": "Changes how often the world is saved in seconds. Default is 1800 seconds (30 minutes).",
+    "Keywords": "save,autosave,interval,time,timer,frequency",
+    "FieldName": "saveinterval",
+    "InputType": "number",
+    "ParamFieldName": "saveinterval",
+    "IncludeInCommandLine": true,
+    "SkipIfEmpty": true,
+    "DefaultValue":"1800",
+    "EnumValues": {},
+    "Suffix": "seconds"
+  },
+  {
     "DisplayName":"Release Stream",
     "Category":"SteamCMD and Updates",
     "Description":"\"public\" is default. Choose a custom release on [SteamDB](https://steamdb.info/app/896660/depots/). NOTE: Update the server after changing release streams.",


### PR DESCRIPTION
Hi! This PR adds support for the Valheim world save interval command line parameter (-saveinterval \<seconds\>). It was added to the game [sometime in 2022](https://store.steampowered.com/news/app/892970/view/3376031059808269643), but I saw AMP doesn't have it yet!

From the "Valheim Dedicated Server Manual":

![image](https://github.com/CubeCoders/AMPTemplates/assets/33547378/d3d847ef-28f0-4dda-811f-d6570f266636)

This is my first contribution here, so forgive me if I got something wrong (should it be left empty by default instead?)