### PR TITLE
Update palworld-moddedconfig.json

### DIFF
--- a/palworld-moddedconfig.json
+++ b/palworld-moddedconfig.json
@@ -89,14 +89,14 @@
         "DisplayName":"Make Community Server",
         "Category":"Palworld Server Settings",
         "Description":"If enabled, the server will appear in the list of community servers in-game",
-        "Keywords":"community,server,public,list,epicapp,palserver",
+        "Keywords":"community,server,public,list,epicapp,palserver,publiclobby",
         "FieldName":"CommunityServer",
         "InputType":"checkbox",
         "ParamFieldName":"CommunityServer",
-        "DefaultValue":"EpicApp=PalServer ",
+        "DefaultValue":"-publiclobby ",
         "EnumValues":{
             "False":"",
-            "True":"EpicApp=PalServer "
+            "True":"-publiclobby "
         }
     },
     {


### PR DESCRIPTION
As of todays update the Developers changed the command to add a Palworld Server to the Public Community list from: 

"EpicApp=PalServer" to "-publiclobby"

source: https://tech.palworldgame.com/settings-and-operation/arguments