### PR TITLE
Python App Runner: avoid git clone issue

### DIFF
--- a/python-app-runnerconfig.json
+++ b/python-app-runnerconfig.json
@@ -186,12 +186,11 @@
     {
         "DisplayName":"App Environment Variables",
         "Category":"App Runner Settings",
-        "Description":"Sets a list of environment variables to run the app with, if applicable. For example, this may include a [Discord bot token](https://discord.com/developers/applications/). Consult any example '.env' file included with the app for relevant variables to specify",
+        "Description":"To set a list of environment variables to run the app with, create a '.env' file in the working directory. For example, this may include a [Discord bot token](https://discord.com/developers/applications/). Consult any example '.env' file included with the app for relevant variables to specify",
         "Keywords":"environment,variables,EnvVars",
         "FieldName":"EnvVars",
-        "InputType":"Textarea",
+        "InputType":"hidden",
         "ParamFieldName":"EnvVars",
-        "DefaultValue":"",
         "EnumValues":{}
     },
     {

--- a/python-app-runnermetaconfig.json
+++ b/python-app-runnermetaconfig.json
@@ -1,15 +1,1 @@
-[
-    {
-        "ConfigFile":"./{{AppDir}}/.env",
-        "ConfigType":"kvp",
-        "ConfigFormat":"{0}{1}",
-        "Subsections":[
-            {
-                "Heading":"$root",
-                "SettingMappings":{
-                    "":"EnvVars"
-                }
-            }
-        ]
-    }
-]
+[]


### PR DESCRIPTION
The metaconfig creates the relevant .env file whenever any setting is changed, causing a `git clone` to fail. This becomes circular as the only way to clone a git repo is to change the setting to specify it. Sigh.