### PR TITLE
MX Bikes: fix server installation

### DIFF
--- a/mxbikesupdates.json
+++ b/mxbikesupdates.json
@@ -1,12 +1,20 @@
 [
     {
-        "UpdateStageName":"SteamCMD Download",
+        "UpdateStageName":"Game Files Download",
         "UpdateSourcePlatform":"All",
         "UpdateSource":"SteamCMD",
         "UpdateSourceData":"655500",
         "UpdateSourceArgs":"655500",
         "UpdateSourceTarget":"{{$FullBaseDir}}",
         "ForceDownloadPlatform":"Windows"
+    },
+    {
+        "UpdateStageName":"Standalone Patch Download",
+        "UpdateSourcePlatform":"All",
+        "UpdateSource":"FetchURL",
+        "UpdateSourceData":"http://www.mx-bikes.com/downloads/mxbikes.exe",
+        "UpdateSourceTarget":"{{$FullBaseDir}}",
+        "OverwriteExistingFiles":true
     },
     {
         "UpdateStageName":"Results Directory Creation",

--- a/mxbikesupdates.json
+++ b/mxbikesupdates.json
@@ -5,6 +5,7 @@
         "UpdateSource":"SteamCMD",
         "UpdateSourceData":"655500",
         "UpdateSourceArgs":"655500",
+        "UpdateSourceTarget":"{{$FullBaseDir}}",
         "ForceDownloadPlatform":"Windows"
     },
     {


### PR DESCRIPTION
The game files are required to run the server (which are easiest to install from Steam), but the server can only run with standalone patch executable.