### PR TITLE
Update mount-and-blade2config.json to fix typo

### DIFF
--- a/mount-and-blade2config.json
+++ b/mount-and-blade2config.json
@@ -47,7 +47,7 @@
         "FieldName":"tickrate",
         "InputType":"number",
         "MinValue":"1",
-        "MinValue":"240",
+        "MaxValue":"240",
         "ParamFieldName":"tickrate",
         "IncludeInCommandLine":true,
         "DefaultValue":"240",


### PR DESCRIPTION
2 times MinValue, one was supposed to be MaxValue.