### PR TITLE
Assetto Corsa Competizione: add new track

### DIFF
--- a/assetto-corsa-compconfig.json
+++ b/assetto-corsa-compconfig.json
@@ -240,6 +240,7 @@
             "monza":"Monza",
             "mount_panorama":"Mount Panorama",
             "nurburgring":"Nurburgring",
+            "nurburgring_24h":"Nurburgring 24h",
             "oulton_park":"Oulton Park",
             "paul_ricard":"Paul Ricard",
             "silverstone":"Silverstone",


### PR DESCRIPTION
Added the new nurburgring 24h track as an option for the track selection.
This track was added with the Assetto Corsa Competizione update from 2024-04-01.