### PR TITLE
Adding missing track configs.

### DIFF
--- a/assetto-corsa-compconfig.json
+++ b/assetto-corsa-compconfig.json
@@ -231,9 +231,11 @@
         "EnumValues":{
             "barcelona":"Barcelona",
             "brands_hatch":"Brands Hatch",
+            "cota":"Circuit of the Americas",
             "donington":"Donington",
             "hungaroring":"Hungaroring",
             "imola":"Imola",
+            "indianapolis":"Indianapolis",
             "kyalami":"Kyalami",
             "laguna_seca":"Laguna Seca",
             "misano":"Misano",
@@ -243,11 +245,13 @@
             "nurburgring_24h":"Nurburgring 24h",
             "oulton_park":"Oulton Park",
             "paul_ricard":"Paul Ricard",
+            "red_bull_ring":"Red Bull Ring",
             "silverstone":"Silverstone",
             "snetterton":"Snetterton",
             "spa":"Spa",
             "suzuka":"Suzuka",
             "valencia":"Valencia",
+            "watkins_glen":"Watkins Glen",
             "zandvoort":"Zandvoort",
             "zolder":"Zolder"
         }


### PR DESCRIPTION
Config options were missing for some of the DLC circuits in Assetto Corsa Competizione.

Added:

-COTA
-Indianapolis
-Red Bull Ring
-Watkins Glen