### PR TITLE
DayZ: Change lightingConfig from bool to number

### DIFF
--- a/dayz-experimentalconfig.json
+++ b/dayz-experimentalconfig.json
@@ -523,20 +523,18 @@
     {
         "DisplayName":"Enable Darker Nights",
         "Category":"DayZ Gameplay Settings",
-        "Description":"If enabled, nights will be darker on the server",
+        "Description":"Use 1 for darker nights on vanilla maps. Modded maps maybe use different values.",
         "Keywords":"light,lighting,dark,night,lightingconfig",
         "FieldName":"lightingConfig",
-        "InputType":"checkbox",
+        "InputType":"number",
         "IsFlagArgument":false,
         "ParamFieldName":"lightingConfig",
         "IncludeInCommandLine":false,
         "DefaultValue":"0",
-        "EnumValues":{
-            "False":"0",
-            "True":"1"
-        }
+        "Placeholder":"0",
+        "EnumValues":{}
     },
-     {
+    {
         "DisplayName":"Disable Base Damage",
         "Category":"DayZ Gameplay Settings",
         "Description":"If set, disables the damage or destruction of fences and watchtowers",

--- a/dayz-experimentalconfig.json
+++ b/dayz-experimentalconfig.json
@@ -523,7 +523,7 @@
     {
         "DisplayName":"Enable Darker Nights",
         "Category":"DayZ Gameplay Settings",
-        "Description":"Use 1 for darker nights on vanilla maps. Modded maps maybe use different values.",
+        "Description":"Use 1 for darker nights on vanilla maps. Modded maps maybe use different values",
         "Keywords":"light,lighting,dark,night,lightingconfig",
         "FieldName":"lightingConfig",
         "InputType":"number",

--- a/dayz-originalconfig.json
+++ b/dayz-originalconfig.json
@@ -523,20 +523,18 @@
     {
         "DisplayName":"Enable Darker Nights",
         "Category":"DayZ Gameplay Settings",
-        "Description":"If enabled, nights will be darker on the server",
+        "Description":"Use 1 for darker nights on vanilla maps. Modded maps maybe use different values.",
         "Keywords":"light,lighting,dark,night,lightingconfig",
         "FieldName":"lightingConfig",
-        "InputType":"checkbox",
+        "InputType":"number",
         "IsFlagArgument":false,
         "ParamFieldName":"lightingConfig",
         "IncludeInCommandLine":false,
         "DefaultValue":"0",
-        "EnumValues":{
-            "False":"0",
-            "True":"1"
-        }
+        "Placeholder":"0",
+        "EnumValues":{}
     },
-     {
+    {
         "DisplayName":"Disable Base Damage",
         "Category":"DayZ Gameplay Settings",
         "Description":"If set, disables the damage or destruction of fences and watchtowers",

--- a/dayz-originalconfig.json
+++ b/dayz-originalconfig.json
@@ -523,7 +523,7 @@
     {
         "DisplayName":"Enable Darker Nights",
         "Category":"DayZ Gameplay Settings",
-        "Description":"Use 1 for darker nights on vanilla maps. Modded maps maybe use different values.",
+        "Description":"Use 1 for darker nights on vanilla maps. Modded maps maybe use different values",
         "Keywords":"light,lighting,dark,night,lightingconfig",
         "FieldName":"lightingConfig",
         "InputType":"number",


### PR DESCRIPTION
I changed the value `lightingConfig` from bool to number.

Some maps do not use `0` or `1` as value (for example `Namalsk` -> [Config Example](https://github.com/SumrakDZN/Namalsk-Server/blob/main/Server%20Config/Regular/serverDZ.cfg)).

In the game engine itself the value seems to be an integer.