### PR TITLE
Updating "exit"-command

### DIFF
--- a/conan-exiles.kvp
+++ b/conan-exiles.kvp
@@ -39,7 +39,7 @@ App.CommandLineParameterFormat=-{0}="{1}"
 App.CommandLineParameterDelimiter= 
 App.ExitMethod=String
 App.ExitTimeout=60
-App.ExitString=exit
+App.ExitString=shutdown
 App.ExitFile=app_exit.lck
 App.HasWriteableConsole=True
 App.HasReadableConsole=True


### PR DESCRIPTION
Got changed a while ago.
It's "shutdown" for "killing" the server nicely

Discovered via "help" in RCON/Console