### PR TITLE
Fix BepInExPack URL for Thunderstore

### DIFF
--- a/valheimconfig.json
+++ b/valheimconfig.json
@@ -311,7 +311,7 @@
   },{
     "DisplayName":"BepInEx Version",
     "Category":"SteamCMD and Updates",
-    "Description":"The version of BepInEx to download. You can find the latest version on [Thunderstore.io](https://valheim.thunderstore.io/package/denikson/BepInExPack_Valheim/). NOTE: Update the server after editing this option.",
+    "Description":"The version of BepInEx to download. You can find the latest version on [Thunderstore.io](https://thunderstore.io/c/valheim/p/denikson/BepInExPack_Valheim/). NOTE: Update the server after editing this option.",
     "Keywords":"Install,BepInEx,version",
     "FieldName":"bepinex_version",
     "InputType":"text",

--- a/valheimupdates.json
+++ b/valheimupdates.json
@@ -58,7 +58,7 @@
     "UpdateStageName": "Fetch BepInEx from Thunderstore",
     "UpdateSourcePlatform": "All",
     "UpdateSource": "FetchURL",
-    "UpdateSourceData": "https://valheim.thunderstore.io/package/download/denikson/BepInExPack_Valheim/{{bepinex_version}}/",
+    "UpdateSourceData": "https://gcdn.thunderstore.io/live/repository/packages/",
     "UpdateSourceArgs": "denikson-BepInExPack_Valheim-{{bepinex_version}}.zip",
     "UpdateSourceConditionSetting": "bepinex_install",
     "UpdateSourceConditionValue": "true",


### PR DESCRIPTION
Old ThunderStore URL caused an empty zip file to be written. That caused a load of exceptions when AMP instance tried to read and extract the empty zip file.