### PR TITLE
Vrising - Removed Reset Day Interval and Day or Reset

### DIFF
--- a/v-risingconfig.json
+++ b/v-risingconfig.json
@@ -2079,28 +2079,6 @@
     }
   },
   {
-    "DisplayName": "Reset Days Interval",
-    "Category": "V Rising - Host Settings",
-    "Description": "Reset the server in x amount of days, use 0 for no resets.  Must be added manually to \"save-data/Settings/ServerHostSettings.json\".  \"ResetDaysInterval\": 0",
-    "Keywords": "reset, days",
-    "FieldName": "ResetDaysInterval",
-    "InputType": "hidden",
-    "IsFlagArgument": false,
-    "ParamFieldName": "ResetDaysInterval",
-    "IncludeInCommandLine": false
-  },
-  {
-    "DisplayName": "Day Of Reset",
-    "Category": "V Rising - Host Settings",
-    "Description": "Day of the week the server resets.  Must be added manually to \"save-data/Settings/ServerHostSettings.json\".  \"DayOfReset\": \"Friday\"",
-    "Keywords": "reset, weekday",
-    "FieldName": "DayOfReset",
-    "InputType": "hidden",
-    "IsFlagArgument": false,
-    "ParamFieldName": "DayOfReset",
-    "IncludeInCommandLine": false
-  },
-  {
     "DisplayName": "Admin Only Debug Events",
     "Category": "V Rising - Host Settings",
     "Description": "Show debug events only to admins",


### PR DESCRIPTION
These options are being modified to unintended values whenever updating Host Settings or whenever the server starts (due to RCON password being updated). Probably better to remove them all together.