### PR TITLE
Adjust ARK Ascended backupExclusions

### DIFF
--- a/exclusions/.backupExclusionsArkSA1
+++ b/exclusions/.backupExclusionsArkSA1
@@ -11,3 +11,5 @@ steamclient.so
 steamclient.dll
 Manifest_UFSFiles_Win64.txt
 Manifest_NonUFSFiles_Win64.txt
+.cache
+.steam

--- a/exclusions/.backupExclusionsArkSA2
+++ b/exclusions/.backupExclusionsArkSA2
@@ -1,2 +1,5 @@
 Binaries
 Content
+Plugins
+Saved/Config/CrashReportClient
+Saved/Logs


### PR DESCRIPTION
Hi,

I looked at one of the generated backup `.zip` files for ARK Ascended and noticed the default template is including a number of directories that are not needed.

Firstly is the base server directory including `.cache` and `.steam` directories.

Then for the game itself, it is including the static Plugins folder, along with all crash reports and logs. Whilst these have some importance, for the purpose of restoring etc, they just take up large amounts of storage for no gain.

![image](https://github.com/CubeCoders/AMPTemplates/assets/1210658/1d1979e3-15c7-4f21-bf57-730efe329593)
![image](https://github.com/CubeCoders/AMPTemplates/assets/1210658/914549ab-0548-44c6-9076-bda283506bdd)
