### PR TITLE
Add Max Transfer Rate setting to Foundry

### DIFF
--- a/foundryconfig.json
+++ b/foundryconfig.json
@@ -89,6 +89,17 @@
         }
     },
     {
+        "DisplayName":"Max Transfer Rate",
+        "Category":"FOUNDRY Server Settings",
+        "Description":"Sets max transfer rate",
+        "Keywords":"transfer,rate,",
+        "FieldName":"maxtransferrate",
+        "InputType":"number",
+        "ParamFieldName":"maxtransferrate",
+        "DefaultValue":"1024",
+        "EnumValues":{}
+    },
+    {
         "DisplayName":"Autosave Interval",
         "Category":"FOUNDRY Server Settings",
         "Description":"Sets the interval between server autosaves",

--- a/foundryconfig.json
+++ b/foundryconfig.json
@@ -89,14 +89,18 @@
         }
     },
     {
-        "DisplayName":"Max Transfer Rate",
+        "DisplayName":"Maximum Data Transfer Rate",
         "Category":"FOUNDRY Server Settings",
-        "Description":"Sets max transfer rate",
-        "Keywords":"transfer,rate,",
-        "FieldName":"maxtransferrate",
+        "Description":"Sets the maximum rate for transfer of server data to clients. Higher values may be needed to avoid timeouts with larger world saves",
+        "Keywords":"transfer,rate,server,data,max_transfer_rate",
+        "FieldName":"max_transfer_rate",
         "InputType":"number",
-        "ParamFieldName":"maxtransferrate",
+        "MinValue":"0",
+        "MaxValue":"8192",
+        "ParamFieldName":"max_transfer_rate",
         "DefaultValue":"1024",
+        "Placeholder":"1024",
+        "Suffix":"kB/s",
         "EnumValues":{}
     },
     {

--- a/foundrymetaconfig.json
+++ b/foundrymetaconfig.json
@@ -17,6 +17,7 @@
                     "server_port":"$ServerPort",
                     "server_query_port":"$QueryPort",
                     "mapseed":"mapseed",
+                    "max_transfer_rate":"maxtransferrate",
                     "server_persistent_data_override_folder":"."
                 }
             }

--- a/foundrymetaconfig.json
+++ b/foundrymetaconfig.json
@@ -17,7 +17,7 @@
                     "server_port":"$ServerPort",
                     "server_query_port":"$QueryPort",
                     "mapseed":"mapseed",
-                    "max_transfer_rate":"maxtransferrate",
+                    "max_transfer_rate":"max_transfer_rate",
                     "server_persistent_data_override_folder":"."
                 }
             }


### PR DESCRIPTION
By adding this setting allows you to speedup save transfer speed when logging in to server