### PR TITLE
VRising Updated Difficulty Values

### DIFF
--- a/v-risingconfig.json
+++ b/v-risingconfig.json
@@ -9,11 +9,11 @@
     "IsFlagArgument": false,
     "ParamFieldName": "GameDifficulty",
     "IncludeInCommandLine": false,
-    "DefaultValue": "Normal",
+    "DefaultValue": "1",
     "EnumValues": {
-      "Easy": "Easy",
-      "Normal": "Normal",
-      "Brutal": "Brutal"
+      "0": "Easy",
+      "1": "Normal",
+      "2": "Brutal"
     }
   },
   {


### PR DESCRIPTION
Updating the difficulty dropdown to use "0","1","2" as this seems to get the intended results better then "Easy","Normal","Brutal" (I've seen the values referred to in both ways).  While using the number values as a string works I will mention that the VRising preset files does use the numeric representation 0,1,2 but that doesn't play nicely with "EnumValues".

Additional clarification - these values only mean something when **not** using a Game Difficulty preset (in Host Settings).  With this update, the server will show the appropriate "Easy" and "Brutal" icons in the server browser list.