### PR TITLE
Fix: Disable Node Download

### DIFF
--- a/nodeconfig.json
+++ b/nodeconfig.json
@@ -120,6 +120,7 @@
         "EnumValues":{
             "False":"false",
             "True":"true"
+        }
     },
     {
         "DisplayName":"Application Name",


### PR DESCRIPTION
The disable node download setting Enum values were missing a closing bracket causing startup failures.