### PR TITLE
Insurgency Sandstorm: Add additional options for configuration from this guide. https://mod.io/g/insurgencysandstorm/r/server-admin-guide

### DIFF
--- a/insurgencysandstormconfig.json
+++ b/insurgencysandstormconfig.json
@@ -1096,5 +1096,152 @@
         "ParamFieldName": "/Script/Insurgency.INSMultiplayerMode.SupplyGainFrequency",
         "DefaultValue": "150",
         "EnumValues": {}
+    },
+    {
+        "DisplayName": "Defend Timer",
+        "Category": "Multiplayer Mode",
+        "Description": "Time to defend against counter attack with small player team.",
+        "Keywords": "Defend,Timer",
+        "FieldName": "DefendTimer",
+        "InputType": "number",
+        "IsFlagArgument": false,
+        "ParamFieldName": "/Script/Insurgency.INSCheckpointGameMode.DefendTimer",
+        "DefaultValue": "90",
+        "EnumValues": {}
+    },
+    {
+        "DisplayName": "Defend Timer Final",
+        "Category": "Multiplayer Mode",
+        "Description": "Extend duration of counter-attack by this on the final point.",
+        "Keywords": "Defend,Timer",
+        "FieldName": "DefendTimerFinal",
+        "InputType": "number",
+        "IsFlagArgument": false,
+        "ParamFieldName": "/Script/Insurgency.INSCheckpointGameMode.DefendTimerFinal",
+        "DefaultValue": "180",
+        "EnumValues": {}
+    },
+    {
+        "DisplayName": "Retreat Timer",
+        "Category": "Multiplayer Mode",
+        "Description": "Time to force bots to retreat after a counter-attack.",
+        "Keywords": "Retreat,Timer",
+        "FieldName": "RetreatTimer",
+        "InputType": "number",
+        "IsFlagArgument": false,
+        "ParamFieldName": "/Script/Insurgency.INSCheckpointGameMode.RetreatTimer",
+        "DefaultValue": "10",
+        "EnumValues": {}
+    },
+    {
+        "DisplayName": "Respawn DPR",
+        "Category": "Multiplayer Mode",
+        "Description": "Dead player ratio that must be reached before respawning the bot team.",
+        "Keywords": "Respawn,DPR",
+        "FieldName": "RespawnDPR",
+        "InputType": "number",
+        "IsFlagArgument": false,
+        "ParamFieldName": "/Script/Insurgency.INSCheckpointGameMode.RespawnDPR",
+        "DefaultValue": "0.1",
+        "EnumValues": {}
+    },
+    {
+        "DisplayName": "Respawn Delay",
+        "Category": "Multiplayer Mode",
+        "Description": "Bot respawn delay.",
+        "Keywords": "Respawn,Delay",
+        "FieldName": "RespawnDelay",
+        "InputType": "number",
+        "IsFlagArgument": false,
+        "ParamFieldName": "/Script/Insurgency.INSCheckpointGameMode.RespawnDelay",
+        "DefaultValue": "20",
+        "EnumValues": {}
+    },
+    {
+        "DisplayName": "Post Capture Rush Timer",
+        "Category": "Multiplayer Mode",
+        "Description": "Bot respawn delay.",
+        "Keywords": "Capture,Timer",
+        "FieldName": "PostCaptureRushTimer",
+        "InputType": "number",
+        "IsFlagArgument": false,
+        "ParamFieldName": "/Script/Insurgency.INSCheckpointGameMode.PostCaptureRushTimer",
+        "DefaultValue": "30",
+        "EnumValues": {}
+    },
+    {
+        "DisplayName": "Counter Attack Respawn DPR",
+        "Category": "Multiplayer Mode",
+        "Description": "Dead player ratio that must be reached before respawning the bot team during a counter-attack.",
+        "Keywords": "Respawn,DPR",
+        "FieldName": "CounterAttackRespawnDPR",
+        "InputType": "number",
+        "IsFlagArgument": false,
+        "ParamFieldName": "/Script/Insurgency.INSCheckpointGameMode.CounterAttackRespawnDPR",
+        "DefaultValue": "0.2",
+        "EnumValues": {}
+    },
+    {
+        "DisplayName": "CounterAttackRespawnDelay",
+        "Category": "Multiplayer Mode",
+        "Description": "Bot respawn delay during counter-attack.",
+        "Keywords": "Respawn,DPR",
+        "FieldName": "CounterAttackRespawnDelay",
+        "InputType": "number",
+        "IsFlagArgument": false,
+        "ParamFieldName": "/Script/Insurgency.INSCheckpointGameMode.CounterAttackRespawnDelay",
+        "DefaultValue": "20",
+        "EnumValues": {}
+    },
+    {
+        "DisplayName": "Objective Total Enemy Respawn Multiplier Min",
+        "Category": "Multiplayer Mode",
+        "Description": "Multiplier of bots to respawn with minimum player count.",
+        "Keywords": "Multiplier,DPR",
+        "FieldName": "ObjectiveTotalEnemyRespawnMultiplierMin",
+        "InputType": "number",
+        "IsFlagArgument": false,
+        "ParamFieldName": "/Script/Insurgency.INSCheckpointGameMode.ObjectiveTotalEnemyRespawnMultiplierMin",
+        "DefaultValue": "1",
+        "EnumValues": {}
+    },
+    {
+        "DisplayName": "Objective Total Enemy Respawn Multiplier Max",
+        "Category": "Multiplayer Mode",
+        "Description": "Multiplier of bots to respawn with maximum player count.",
+        "Keywords": "Multiplier,DPR",
+        "FieldName": "ObjectiveTotalEnemyRespawnMultiplierMax",
+        "InputType": "number",
+        "IsFlagArgument": false,
+        "ParamFieldName": "/Script/Insurgency.INSCheckpointGameMode.ObjectiveTotalEnemyRespawnMultiplierMax",
+        "DefaultValue": "1",
+        "EnumValues": {}
+    },
+    {
+        "DisplayName": "Final Cache Bot Quota Multiplier",
+        "Category": "Multiplayer Mode",
+        "Description": "Increase in bot quota for final objective if it’s a cache.",
+        "Keywords": "Final,BOT",
+        "FieldName": "FinalCacheBotQuotaMultiplier",
+        "InputType": "number",
+        "IsFlagArgument": false,
+        "ParamFieldName": "/Script/Insurgency.INSCheckpointGameMode.FinalCacheBotQuotaMultiplier",
+        "DefaultValue": "1.5",
+        "EnumValues": {}
+    },
+    {
+        "DisplayName": "Reinforment Waves",
+        "Category": "Multiplayer Mode",
+        "Description": "Increase in bot quota for final objective if it’s a cache.",
+        "Keywords": "Final,BOT",
+        "FieldName": "bForceSoloWaves",
+        "InputType": "number",
+        "IsFlagArgument": false,
+        "ParamFieldName": "/Script/Insurgency.INSCheckpointGameMode.bForceSoloWaves",
+        "DefaultValue": "True",
+        "EnumValues": {
+            "False": "False",
+            "True": "True"
+        }
     }
 ]


### PR DESCRIPTION
This adds additional configuration fields for the game.ini the following fields to be added.

[/Script/Insurgency.INSCheckpointGameMode]
DefendTimer=90
DefendTimerFinal=180
RetreatTimer=10
RespawnDPR=0.1
RespawnDelay=20
PostCaptureRushTimer=30
CounterAttackRespawnDPR=0.2
CounterAttackRespawnDelay=20
ObjectiveTotalEnemyRespawnMultiplierMin=1
ObjectiveTotalEnemyRespawnMultiplierMax=1
FinalCacheBotQuotaMultiplier=1.5
bForceSoloWaves=True