### PR TITLE
NightOfTheDead: Allow the setting UnlockAllBuildings to be set in config file

### DIFF
--- a/night-of-the-deadconfig.json
+++ b/night-of-the-deadconfig.json
@@ -965,5 +965,21 @@
             "240":"240",
             "300":"300"
         }
+    },
+    {
+        "DisplayName":"Unlock All Buildings",
+        "Category":"NOTD Custom Settings",
+        "Description":"Allows all buildings to be build, not just the unlocked ones",
+        "Keywords":"game",
+        "FieldName":"UnlockAllBuilding",
+        "InputType":"enum",
+        "IsFlagArgument":false,
+        "ParamFieldName":"UnlockAllBuilding",
+        "IncludeInCommandLine":false,
+        "DefaultValue":"0",
+        "EnumValues":{
+            "0":"0",
+            "1":"1"
+        }
     }
 ]

--- a/night-of-the-deadserversettings.ini
+++ b/night-of-the-deadserversettings.ini
@@ -117,3 +117,5 @@ ElectricStandbyPower={{ElectricStandbyPower}}
 [GameSettings/Detail]
 ; 60 / 120 / 180 / 240 / 300
 OneDayTime={{OneDayTime}}
+; 0 = disable, 1 = enable
+UnlockAllBuilding={{UnlockAllBuilding}} // Unlock All Buildings


### PR DESCRIPTION
According to server documentation, and local testing, it is possible to configure so that all buildings can be created even if not unlocked yet in main story. This allows for a more QOL experience, and I would like it to be available as a setting for the AMP template for the game.

https://steamcommunity.com/sharedfiles/filedetails/?id=2252239447