### PR TITLE
Satisfactory - add join/leave regex

### DIFF
--- a/satisfactory.kvp
+++ b/satisfactory.kvp
@@ -33,7 +33,7 @@ App.ExecutableLinux=1690800/Engine/Binaries/Linux/FactoryServer-Linux-Shipping
 App.WorkingDir=1690800
 App.LinuxCommandLineArgs=
 App.WindowsCommandLineArgs=
-App.CommandLineArgs={{$PlatformArgs}} FactoryGame -MultiHome={{$ApplicationIPBinding}} -Port={{$ApplicationPort1}} -ini:Engine:[HTTPServer.Listeners]:DefaultBindAddress={{$ApplicationIPBinding}} {{DisableSeasonalEvents}} {{$FormattedArgs}} -log -unattended
+App.CommandLineArgs={{$PlatformArgs}} FactoryGame -MultiHome={{$ApplicationIPBinding}} -Port={{$ApplicationPort1}} -ini:Engine:[HTTPServer.Listeners]:DefaultBindAddress={{$ApplicationIPBinding}} {{DisableSeasonalEvents}} {{$FormattedArgs}} -stdout -FullStdOutLogOutput -unattended
 App.UseLinuxIOREDIR=False
 App.AppSettings={}
 App.EnvironmentVariables={"LD_LIBRARY_PATH":"{{$FullBaseDir}}linux64:%LD_LIBRARY_PATH%","SteamAppId":"526870"}
@@ -84,8 +84,8 @@ Console.FilterMatchRegex=^\[.+?\]\[.+?\]
 Console.FilterMatchReplacement=
 Console.ThrowawayMessageRegex=^(WARNING|ERROR): Shader.+$
 Console.AppReadyRegex=^LogInit: Display: Game Engine Initialized\.$
-Console.UserJoinRegex=^User (?<username>.+?) \((?<userid>-?d+)\) connected from \[::ffff:(?<endpoint>.+?)\]$
-Console.UserLeaveRegex=^User (?<username>.+?) \((?<userid>-?d+)\) disconnected\. Reason: (.+?)$
+Console.UserJoinRegex=^LogNet: Login request: \?ClientIdentity=.+\?EntryTicket=.+?EncryptionToken=.+\?Name=(?<username>.+?) userId: .+RepData=\[(?<userid>.+)\]\) platform: .+$
+Console.UserLeaveRegex=^LogNet: UChannel\:\:Close\: Sending CloseBunch\. ChIndex == .+\. Name: \[UChannel\] ChIndex: .+\, Closing: \d+ \[UNetConnection\] RemoteAddr: \d+.\d+.\d+.\d+:\d+\, Name: IpConnection_\d+\, Driver: GameNetDriver .+\, IsServer: YES\, PC: .+\, Owner: .+\, UniqueId: .+ \(ForeignId=\[Type=.+ Handle=.+ RepData=\[(?<userid>.+)\]\)$
 Console.UserChatRegex=^$
 Console.UpdateAvailableRegex=^\[\d\d:\d\d:\d\d\] \[INFO\] A new server update is available! v[\d\.]+.$
 Console.MetricsRegex=

--- a/satisfactory.kvp
+++ b/satisfactory.kvp
@@ -84,8 +84,8 @@ Console.FilterMatchRegex=^\[.+?\]\[.+?\]
 Console.FilterMatchReplacement=
 Console.ThrowawayMessageRegex=^(WARNING|ERROR): Shader.+$
 Console.AppReadyRegex=^LogInit: Display: Game Engine Initialized\.$
-Console.UserJoinRegex=^LogNet: Login request: \?ClientIdentity=.+\?EntryTicket=.+?EncryptionToken=.+\?Name=(?<username>.+?) userId: .+RepData=\[(?<userid>.+)\]\) platform: .+$
-Console.UserLeaveRegex=^LogNet: UChannel\:\:Close\: Sending CloseBunch\. ChIndex == .+\. Name: \[UChannel\] ChIndex: .+\, Closing: \d+ \[UNetConnection\] RemoteAddr: \d+.\d+.\d+.\d+:\d+\, Name: IpConnection_\d+\, Driver: GameNetDriver .+\, IsServer: YES\, PC: .+\, Owner: .+\, UniqueId: .+ \(ForeignId=\[Type=.+ Handle=.+ RepData=\[(?<userid>.+)\]\)$
+Console.UserJoinRegex=^LogNet: Login request: \?ClientIdentity=.+\?EntryTicket=.+?EncryptionToken=.+\?Name=(?<username>.+?) userId: .+\(ForeignId=\[Type=.+ Handle=.+ RepData=\[(?<userid>.+)\]\) platform: .+$
+Console.UserLeaveRegex=^LogNet: UChannel\:\:Close\: Sending CloseBunch\. ChIndex == .+\. Name: \[UChannel\] ChIndex: .+\, Closing: .+ \[UNetConnection\] RemoteAddr: .+\, Name: .+, Driver: .+\, IsServer: YES\, PC: .+\, Owner: .+\, UniqueId: .+ \(ForeignId=\[Type=.+ Handle=.+ RepData=\[(?<userid>.+)\]\)
 Console.UserChatRegex=^$
 Console.UpdateAvailableRegex=^\[\d\d:\d\d:\d\d\] \[INFO\] A new server update is available! v[\d\.]+.$
 Console.MetricsRegex=


### PR DESCRIPTION
Changed `-log` to `-stdout -FullStdOutLogOutput` for more verbose logging. Log lines are not great but this regex works.

Join line example:
```
LogNet: Login request: ?ClientIdentity=2100000064316461376562353439343039613466653366373263626464643633316661660001000000012100000003621e6db9e5794ea3a90621c55c151e0100025cbba00a4a1d894dad87c5459564?EntryTicket=ew0KCSJwbCI6ICJBZG1pbmlzdHJhdG9yIiwNCgkiaWR0IjogIjE3MjYwMzEyNDYiDQp9.C41E2B1D7FAFA3B42B30554CA37B83418DB46DD1C6E2478529D63ACA4F293D3DC34B142BF8EB1C440A4B6056CB626C7A0752D9AC99F8BBE441AB8516D2CF650A?EncryptionToken=5339856C83B81BD43BD538BA11740B2833B6BDC3A83FAF7006C6C5DD4BC790B0?Name=winglessraven userId: Epic:1 (ForeignId=[Type=1 Handle=0 RepData=[03621E6DB9E5794EA3A90621C55C151E0100025CBBA00A4A1D894DAD87C5459564]) platform: NULL
```

Leave line example:
```
LogNet: UChannel::Close: Sending CloseBunch. ChIndex == 0. Name: [UChannel] ChIndex: 0, Closing: 0 [UNetConnection] RemoteAddr: 94.193.199.94:53106, Name: IpConnection_2147473689, Driver: GameNetDriver FGDSIpNetDriver_2147482258, IsServer: YES, PC: BP_PlayerController_C_2147473509, Owner: BP_PlayerController_C_2147473509, UniqueId: Epic:1 (ForeignId=[Type=1 Handle=0 RepData=[03621E6DB9E5794EA3A90621C55C151E0100025CBBA00A4A1D894DAD87C5459564])
```

