### PR TITLE
Update foundry-vttupdates.json to override existing files on node download

### DIFF
--- a/foundry-vttupdates.json
+++ b/foundry-vttupdates.json
@@ -66,7 +66,7 @@
         "UpdateSourceTarget":"{{$FullBaseDir}}",
         "UnzipUpdateSource":true,
         "OverwriteExistingFiles":true,
-        "DeleteAfterExtract":true,
+        "DeleteAfterExtract":true
     },
     {
         "UpdateStageName":"Node.js Extract",

--- a/foundry-vttupdates.json
+++ b/foundry-vttupdates.json
@@ -28,7 +28,8 @@
         "UpdateSource":"FetchURL",
         "UpdateSourceData":"https://nodejs.org/download/release/{{NodeVersion}}/node-{{NodeVersion}}-linux-x64.tar.gz",
         "UpdateSourceArch":"x86_64",
-        "UpdateSourceTarget":"{{$FullBaseDir}}"
+        "UpdateSourceTarget":"{{$FullBaseDir}}",
+        "OverwriteExistingFiles":true
     },
     {
         "UpdateStageName":"Node.js Extract",
@@ -45,7 +46,8 @@
         "UpdateSource":"FetchURL",
         "UpdateSourceData":"https://nodejs.org/download/release/{{NodeVersion}}/node-{{NodeVersion}}-linux-arm64.tar.gz",
         "UpdateSourceArch":"aarch64",
-        "UpdateSourceTarget":"{{$FullBaseDir}}"
+        "UpdateSourceTarget":"{{$FullBaseDir}}",
+        "OverwriteExistingFiles":true
     },
     {
         "UpdateStageName":"Node.js Extract",
@@ -64,7 +66,8 @@
         "UpdateSourceTarget":"{{$FullBaseDir}}",
         "UnzipUpdateSource":true,
         "OverwriteExistingFiles":true,
-        "DeleteAfterExtract":true
+        "DeleteAfterExtract":true,
+        "OverwriteExistingFiles":true
     },
     {
         "UpdateStageName":"Node.js Extract",

--- a/foundry-vttupdates.json
+++ b/foundry-vttupdates.json
@@ -67,7 +67,6 @@
         "UnzipUpdateSource":true,
         "OverwriteExistingFiles":true,
         "DeleteAfterExtract":true,
-        "OverwriteExistingFiles":true
     },
     {
         "UpdateStageName":"Node.js Extract",


### PR DESCRIPTION
The node.js archive is deleted on the extract update stage. So, it should always download a fresh copy of node.js. If, for some reason, there is a corrupted file left over, it should just override it instead of trying to use it.