### PR TITLE
Project Zomboid: Java class setting workaround

### DIFF
--- a/project-zomboid.kvp
+++ b/project-zomboid.kvp
@@ -26,9 +26,9 @@ App.BaseDirectory=./project-zomboid/380870/
 App.ExecutableWin=380870\jre64\bin\java.exe
 App.ExecutableLinux=380870/jre64/bin/java
 App.WorkingDir=380870
-App.LinuxCommandLineArgs=-Dfile.encoding=UTF-8 -Djava.awt.headless=true -Dzomboid.znetlog=1 -Dzomboid.steam={{SteamInt}} -Duser.home=./ -Xmx{{MaxMemory}}m -XX:+UseZGC -XX:-OmitStackTraceInFastThrow -Djava.library.path=linux64/:natives/ -Djava.security.egd=file:/dev/urandom {{CustomJavaArgs}} -cp java/:java/* {{JavaClass}}
-App.WindowsCommandLineArgs=-Dfile.encoding=UTF-8 -Djava.awt.headless=true -Dzomboid.znetlog=1 -Dzomboid.steam={{SteamInt}} -Duser.home=./ -Xmx{{MaxMemory}}m {{JavaGCAlgo}} -XX:-CreateCoredumpOnCrash -XX:-OmitStackTraceInFastThrow -Djava.library.path=natives/;natives/win64/;. {{CustomJavaArgs}} -cp java/*;java/ {{JavaClass}}
-App.CommandLineArgs={{$PlatformArgs}} -port {{$ApplicationPort1}} -udpport {{$ApplicationPort2}} {{CustomServerArgs}} {{$FormattedArgs}}
+App.LinuxCommandLineArgs=-Dfile.encoding=UTF-8 -Djava.awt.headless=true -Dzomboid.znetlog=1 -Dzomboid.steam={{SteamInt}} -Duser.home=./ -Xmx{{MaxMemory}}m -XX:+UseZGC -XX:-OmitStackTraceInFastThrow -Djava.library.path=linux64/:natives/ -Djava.security.egd=file:/dev/urandom {{CustomJavaArgs}} -cp java/:java/*
+App.WindowsCommandLineArgs=-Dfile.encoding=UTF-8 -Djava.awt.headless=true -Dzomboid.znetlog=1 -Dzomboid.steam={{SteamInt}} -Duser.home=./ -Xmx{{MaxMemory}}m {{JavaGCAlgo}} -XX:-CreateCoredumpOnCrash -XX:-OmitStackTraceInFastThrow -Djava.library.path=natives/;natives/win64/;. {{CustomJavaArgs}} -cp java/*;java/
+App.CommandLineArgs={{$PlatformArgs}} {{JavaClass}} -port {{$ApplicationPort1}} -udpport {{$ApplicationPort2}} {{CustomServerArgs}} {{$FormattedArgs}}
 App.UseLinuxIOREDIR=False
 App.AppSettings={}
 App.EnvironmentVariables={"PATH":"{{$FullBaseDir}}jre64/bin:%PATH%","LD_LIBRARY_PATH":"{{$FullBaseDir}}linux64:{{$FullBaseDir}}natives:{{$FullBaseDir}}:{{$FullBaseDir}}jre64/lib/amd64:%LD_LIBRARY_PATH%","LD_PRELOAD":"{{$FullBaseDir}}jre64/lib/libjsig.so","SteamAppId":"108600"}


### PR DESCRIPTION
Works around the issue that a variable that refers to another variable is not populated correctly by $PlatformArgs: https://github.com/CubeCoders/AMP/issues/1209