### PR TITLE
Eco: add specific Windows exit method

### DIFF
--- a/eco.kvp
+++ b/eco.kvp
@@ -30,6 +30,7 @@ App.EnvironmentVariables={"LD_LIBRARY_PATH":"{{$FullBaseDir}}linux64:%LD_LIBRARY
 App.CommandLineParameterFormat=-{0} {1}
 App.CommandLineParameterDelimiter= 
 App.ExitMethod=OS_CLOSE
+App.ExitMethodWindows=CtrlC
 App.ExitTimeout=30
 App.ExitString=stop
 App.ExitFile=app_exit.lck


### PR DESCRIPTION
In anticipation of 2.6.0.6