### PR TITLE
Update factorio.kvp so Console.UserChatRegex= works correctly.

### DIFF
--- a/factorio.kvp
+++ b/factorio.kvp
@@ -91,7 +91,7 @@ Console.ThrowawayMessageRegex=^((WARNING|ERROR): Shader.+)$
 Console.AppReadyRegex=$
 Console.UserJoinRegex=^[\d-]+ [\d:]+ \[JOIN\] (?<username>.+?) joined the game$
 Console.UserLeaveRegex=^[\d-]+ [\d:]+ \[LEAVE\] (?<username>.+?) left the game$
-Console.UserChatRegex=^[\d-]+ [\d:]+ \[CHAT\] (?<username>(?!\<server\>).+?) (?<message>(?!\[gps=.*\]).+)$
+Console.UserChatRegex=^[\d-]+ [\d:]+ \[CHAT\] (?<username>(?!<server>).+?): (?<message>(?!\[gps=.*?\]).*)$
 Console.UpdateAvailableRegex=^\[\d\d:\d\d:\d\d\] \[INFO\] A new server update is available! v[\d\.]+.$
 Console.MetricsRegex=
 Console.SuppressLogAtStart=False


### PR DESCRIPTION
Previous Console.UserChatRegex was not javascript regex compliant.  Fixed and tested working on 2.0.28 of Factorio.