### PR TITLE
Add VC2017 to space engineers wine script (to fix server not starting in Docker)

### DIFF
--- a/space-engineers-genericwinescript.sh
+++ b/space-engineers-genericwinescript.sh
@@ -23,6 +23,7 @@ export DISPLAY=:$DPY_NUM
 ./winetricks corefonts > winescript_log.txt 2>&1
 ./winetricks sound=disabled >> winescript_log.txt 2>&1
 ./winetricks -q vcrun2013 >> winescript_log.txt 2>&1
+./winetricks -q vcrun2017 >> winescript_log.txt 2>&1
 ./winetricks -q vcrun2019 >> winescript_log.txt 2>&1
 ./winetricks -q dotnet48 >> winescript_log.txt 2>&1
 rm -rf ~/.cache/winetricks ~/.cache/fontconfig


### PR DESCRIPTION
Hi!

This PR fixes Space Engineers instances not starting when using Linux (Docker).

### How and why:

I use AMP with Debian 12 + Docker.

For me, every clean instance of the Space Engineers server would crash with some cryptic DLL error no matter how many times I recreated the instance:

`Exception while loading world: An error occurred while loading the world.`

In the log:

`ERROR Entity init!: System.DllNotFoundException: Unable to load DLL 'VRage.Native.dll': Module not found. `

So I investigated online, and found that the server needs VC2017.

After I added it to the script, the instances immediately started working.