### PR TITLE
Enshrouded: Fix tamingStartleRepercussion setting

### DIFF
--- a/enshroudedconfig.json
+++ b/enshroudedconfig.json
@@ -632,7 +632,7 @@
         "ParamFieldName": "$.gameSettings.tamingStartleRepercussion",
         "DefaultValue": "LoseSomeProgress",
         "EnumValues": {
-            "KeepAllProgress": "Keep all progress",
+            "KeepProgress": "Keep all progress",
             "LoseSomeProgress": "Lose some progress (default)",
             "LoseAllProgress": "Lose all progress"
         }


### PR DESCRIPTION
Fix for issue #1282 

The values for `tamingStartleRepercussion` should be `KeepProgress` / `LoseSomeProgress` / `LoseAllProgress` according to the [documentation](https://enshrouded.zendesk.com/hc/en-us/articles/20453241249821-Server-Difficulty-Settings)

The current values in the settings are 
```
"EnumValues": {
    "KeepAllProgress": "Keep all progress",
    "LoseSomeProgress": "Lose some progress (default)",
    "LoseAllProgress": "Lose all progress"
}
```

`KeepAllProgress` should be `KeepProgress`