### PR TITLE
Arma Reforger: stop overwriting BE config

### DIFF
--- a/arma-reforgermetaconfig.json
+++ b/arma-reforgermetaconfig.json
@@ -4,19 +4,5 @@
         "AutoMap": true,
         "ConfigType": "template",
         "ConfigFileTemplate": "arma-reforger/AMP_serverconfig.json"
-    },
-    {
-        "ConfigFile": "battleye/BEServer_x64.cfg",
-        "ConfigType": "kvp",
-        "ConfigFormat": "{0} {1}",
-        "Subsections": [
-            {
-                "Heading": "$root",
-                "SettingMappings": {
-                    "GameID": "armar",
-                    "MasterPort": "2001"
-                }
-            }
-        ]
     }
 ]


### PR DESCRIPTION
Users can now configure BE RCON separately if they *really* want to

Ideally this would all be built into the template (separate BE RCON port etc) but Generic still can't automatically add ports to existing instances, so the config would be broken on existing instances. Rip