### PR TITLE
Update squad-dedicated-server.kvp

### DIFF
--- a/squad-dedicated-server.kvp
+++ b/squad-dedicated-server.kvp
@@ -1,7 +1,7 @@
 App.AdminMethod=STDIO
 App.ApplicationReadyMode=RegexMatch
 App.BaseDirectory=./squad-dedicated-server/403240/
-App.CommandLineArgs=MULTIHOME={{$ApplicationIPBinding}} Port={{$ApplicationPort1}} QueryPort={{$ApplicationPort2}} RCONPORT={{$RemoteAdminPort}} RCONPASSWORD={{$RemoteAdminPassword}} FIXEDMAXTICKRATE={{MaxTPS}} -beaconport={{$ApplicationPort3}} -log -fullcrashdump
+App.CommandLineArgs=Port={{$ApplicationPort1}} QueryPort={{$ApplicationPort2}} RCONPORT={{$RemoteAdminPort}} RCONPASSWORD={{$RemoteAdminPassword}} FIXEDMAXTICKRATE={{MaxTPS}} -beaconport={{$ApplicationPort3}} -log -fullcrashdump
 App.CommandLineParameterDelimiter= 
 App.CommandLineParameterFormat={0}="{1}"
 App.DisplayName=Squad


### PR DESCRIPTION
Removing the MULTIHOME argument until a full solution is found. This causes the game server to be unjoinable even when choosing a specific IP or 0.0.0.0.