### PR TITLE
Updated Nukkit CI download URL

### DIFF
--- a/nukkitupdates.json
+++ b/nukkitupdates.json
@@ -3,7 +3,7 @@
         "UpdateStageName": "Nukkit Download",
         "UpdateSourcePlatform": "All",
         "UpdateSource": "FetchURL",
-        "UpdateSourceData": "https://ci.opencollab.dev/job/NukkitX/job/Nukkit/job/master/lastStableBuild/artifact/target/nukkit-1.0-SNAPSHOT.jar",
+        "UpdateSourceData": "https://repo.opencollab.dev/api/maven/latest/file/maven-snapshots/cn/nukkit/nukkit/1.0-SNAPSHOT?extension=jar",
         "UpdateSourceTarget": "{{$FullBaseDir}}",
         "UpdateSourceArgs": "nukkit.jar",
         "OverwriteExistingFiles": true


### PR DESCRIPTION
Old: <https://ci.opencollab.dev/job/NukkitX/job/Nukkit/job/master/lastStableBuild/artifact/target/nukkit-1.0-SNAPSHOT.jar>
New: <https://repo.opencollab.dev/api/maven/latest/file/maven-snapshots/cn/nukkit/nukkit/1.0-SNAPSHOT?extension=jar>

Also appears a newline was magically added to the end there, guess it's no longer a one-liner lol