### PR TITLE
Update arma-reforgerserver1-5.json

### DIFF
--- a/arma-reforgerserver1-5.json
+++ b/arma-reforgerserver1-5.json
@@ -1,7 +1,7 @@
 {
     "bindAddress": "{{bindAddress}}",
     "bindPort": {{bindPort}},
-    "publicAddress": "{{publicAddress}}",
+    "publicAddress": "{{bindAddress}}",
     "publicPort": {{publicPort}},
     "a2s": {
         "address": "{{a2s.address}}",


### PR DESCRIPTION
Changes the public address to be the same as bindAddress. This fixes it binding to wrong IP when using multiple IPs on a machine.