### PR TITLE
Killing Floor 2: Added support for custom command-line arguments

### DIFF
--- a/killing-floor-2.kvp
+++ b/killing-floor-2.kvp
@@ -16,7 +16,7 @@ Meta.ContainerPolicyReason=AMP's console is unable to provide console output on 
 Meta.Prerequisites=[]
 Meta.ConfigReleaseState=NotSpecified
 Meta.AppConfigId=75f76d07-e6a2-4b45-868a-8fc7e9bea137
-Meta.ConfigVersion=1.1
+Meta.ConfigVersion=1.2
 App.DisplayName=Killing Floor 2
 App.RootDir=./killing-floor-2/
 App.BaseDirectory=./killing-floor-2/232130/
@@ -25,7 +25,7 @@ App.ExecutableLinux=232130/Binaries/Win64/KFGameSteamServer.bin.x86_64
 App.WorkingDir=232130
 App.LinuxCommandLineArgs=
 App.WindowsCommandLineArgs=
-App.CommandLineArgs={{Map}}?Game={{Game}}?maxplayers={{$MaxUsers}} -Port={{$ApplicationPort1}} -QueryPort={{$ApplicationPort2}} -WebAdminPort={{$RemoteAdminPort}} -Multihome={{$ApplicationIPBinding}} {{$FormattedArgs}}
+App.CommandLineArgs={{Map}}?Game={{Game}}?maxplayers={{$MaxUsers}} -Port={{$ApplicationPort1}} -QueryPort={{$ApplicationPort2}} -WebAdminPort={{$RemoteAdminPort}} -Multihome={{$ApplicationIPBinding}} {{$FormattedArgs}} {{CustomArgs}}
 App.AppSettings={}
 App.EnvironmentVariables={"LD_LIBRARY_PATH":"{{$FullBaseDir}}linux64:{{$FullRootDir}}linux64:%LD_LIBRARY_PATH%","SteamAppId":"232090"}
 App.CommandLineParameterFormat=-{0}="{1}"

--- a/killing-floor-2.kvp
+++ b/killing-floor-2.kvp
@@ -25,7 +25,7 @@ App.ExecutableLinux=232130/Binaries/Win64/KFGameSteamServer.bin.x86_64
 App.WorkingDir=232130
 App.LinuxCommandLineArgs=
 App.WindowsCommandLineArgs=
-App.CommandLineArgs={{Map}}?Game={{Game}}?maxplayers={{$MaxUsers}}{{CustomArgs}} -Port={{$ApplicationPort1}} -QueryPort={{$ApplicationPort2}} -WebAdminPort={{$RemoteAdminPort}} -Multihome={{$ApplicationIPBinding}} {{$FormattedArgs}}
+App.CommandLineArgs={{Map}}?Game={{Game}}?maxplayers={{$MaxUsers}}{{CustomUrlArgs}} -Port={{$ApplicationPort1}} -QueryPort={{$ApplicationPort2}} -WebAdminPort={{$RemoteAdminPort}} -Multihome={{$ApplicationIPBinding}} {{CustomFlags}} {{$FormattedArgs}}
 App.AppSettings={}
 App.EnvironmentVariables={"LD_LIBRARY_PATH":"{{$FullBaseDir}}linux64:{{$FullRootDir}}linux64:%LD_LIBRARY_PATH%","SteamAppId":"232090"}
 App.CommandLineParameterFormat=-{0}="{1}"

--- a/killing-floor-2.kvp
+++ b/killing-floor-2.kvp
@@ -25,7 +25,7 @@ App.ExecutableLinux=232130/Binaries/Win64/KFGameSteamServer.bin.x86_64
 App.WorkingDir=232130
 App.LinuxCommandLineArgs=
 App.WindowsCommandLineArgs=
-App.CommandLineArgs={{Map}}?Game={{Game}}?maxplayers={{$MaxUsers}}{{CustomUrlArgs}} -Port={{$ApplicationPort1}} -QueryPort={{$ApplicationPort2}} -WebAdminPort={{$RemoteAdminPort}} -Multihome={{$ApplicationIPBinding}} {{CustomFlags}} {{$FormattedArgs}}
+App.CommandLineArgs={{Map}}{{CustomUrlArgs}}?Game={{Game}}?MaxPlayers={{$MaxUsers}} -Port={{$ApplicationPort1}} -QueryPort={{$ApplicationPort2}} -WebAdminPort={{$RemoteAdminPort}} -Multihome={{$ApplicationIPBinding}} {{$FormattedArgs}} {{CustomSwitches}}
 App.AppSettings={}
 App.EnvironmentVariables={"LD_LIBRARY_PATH":"{{$FullBaseDir}}linux64:{{$FullRootDir}}linux64:%LD_LIBRARY_PATH%","SteamAppId":"232090"}
 App.CommandLineParameterFormat=-{0}="{1}"

--- a/killing-floor-2.kvp
+++ b/killing-floor-2.kvp
@@ -25,7 +25,7 @@ App.ExecutableLinux=232130/Binaries/Win64/KFGameSteamServer.bin.x86_64
 App.WorkingDir=232130
 App.LinuxCommandLineArgs=
 App.WindowsCommandLineArgs=
-App.CommandLineArgs={{Map}}?Game={{Game}}?maxplayers={{$MaxUsers}} -Port={{$ApplicationPort1}} -QueryPort={{$ApplicationPort2}} -WebAdminPort={{$RemoteAdminPort}} -Multihome={{$ApplicationIPBinding}} {{$FormattedArgs}} {{CustomArgs}}
+App.CommandLineArgs={{Map}}?Game={{Game}}?maxplayers={{$MaxUsers}}{{CustomArgs}} -Port={{$ApplicationPort1}} -QueryPort={{$ApplicationPort2}} -WebAdminPort={{$RemoteAdminPort}} -Multihome={{$ApplicationIPBinding}} {{$FormattedArgs}}
 App.AppSettings={}
 App.EnvironmentVariables={"LD_LIBRARY_PATH":"{{$FullBaseDir}}linux64:{{$FullRootDir}}linux64:%LD_LIBRARY_PATH%","SteamAppId":"232090"}
 App.CommandLineParameterFormat=-{0}="{1}"

--- a/killing-floor-2config.json
+++ b/killing-floor-2config.json
@@ -269,27 +269,29 @@
         "EnumValues": {}
     },
     {
-        "DisplayName": "Additional URL-style Arguments",
+        "DisplayName": "Additional Command Line URL Arguments",
         "Category": "Killing Floor 2:stadia_controller",
         "Subcategory": "Server:dns:1",
-        "Description": "Specify additional [URL-style startup arguments](https://wiki.killingfloor2.com/index.php?title=Dedicated_Server_(Killing_Floor_2%29) to be injected directly into the command line. Example: Mutator=KFMutator.MyMutator. Don't use arguments already in AMP's settings!",
-        "Keywords": "custom,url,arguments,parameters",
+        "Description": "Sets additional [command line URL arguments](https://wiki.killingfloor2.com/index.php?title=Dedicated_Server_(Killing_Floor_2%29#Command_Line_Launch_Options) for the server (those that start with a ? (question mark)). Include the question mark but do not separate with a space. Don't use options already in AMP's settings!",
+        "Keywords": "custom,command,line,options,url,arguments",
         "FieldName": "CustomUrlArgs",
         "InputType": "text",
         "ParamFieldName": "CustomUrlArgs",
         "DefaultValue": "",
+        "Placeholder": "?Mutator=KFMutator.MyMutator",
         "EnumValues": {}
     },
     {
-        "DisplayName": "Additional Flags Arguments",
+        "DisplayName": "Additional Command Line Switches",
         "Category": "Killing Floor 2:stadia_controller",
         "Subcategory": "Server:dns:1",
-        "Description": "Specify additional [command-line flags](https://wiki.killingfloor2.com/index.php?title=Dedicated_Server_(Killing_Floor_2%29). Example: -NoSteamClient -SomeOtherFlag. Don't use flags already in AMP's settings!",
-        "Keywords": "custom,flags,arguments,flags",
-        "FieldName": "CustomFlags",
+        "Description": "Sets additional [command line switches](https://wiki.killingfloor2.com/index.php?title=Dedicated_Server_(Killing_Floor_2%29#Command_Line_Launch_Options) for the server (those that start with a - (dash)). Include the dash and separate with a space. Don't use switches already in AMP's settings!",
+        "Keywords": "custom,command,line,switches",
+        "FieldName": "CustomSwitches",
         "InputType": "text",
-        "ParamFieldName": "CustomFlags",
+        "ParamFieldName": "CustomSwitches",
         "DefaultValue": "",
+        "Placeholder": "-NoSteamClient -PreferredProcessor=2",
         "EnumValues": {}
     }
 ]

--- a/killing-floor-2config.json
+++ b/killing-floor-2config.json
@@ -269,14 +269,26 @@
         "EnumValues": {}
     },
     {
-        "DisplayName": "Additional Command Line Arguments",
+        "DisplayName": "Additional URL-style Arguments",
         "Category": "Killing Floor 2:stadia_controller",
         "Subcategory": "Server:dns:1",
-        "Description": "Specify additional startup arguments to be injected between the URL-style variables and the dash-prefixed command-line flags. Ordering is important: URL-style arguments (e.g., ?Mutator=KFMutator.YourMutator) must come first, followed by any dash-style flags (e.g., -NoSteamClient). Example: ?AdminPassword=123?Mutator=KFMutator.MyMutator -NoSteamClient",
-        "Keywords": "custom,server,arguments,parameters",
-        "FieldName": "CustomArgs",
+        "Description": "Specify additional [URL-style startup arguments](https://wiki.killingfloor2.com/index.php?title=Dedicated_Server_(Killing_Floor_2%29) to be injected directly into the command line. Example: Mutator=KFMutator.MyMutator. Don't use arguments already in AMP's settings!",
+        "Keywords": "custom,url,arguments,parameters",
+        "FieldName": "CustomUrlArgs",
         "InputType": "text",
-        "ParamFieldName": "CustomArgs",
+        "ParamFieldName": "CustomUrlArgs",
+        "DefaultValue": "",
+        "EnumValues": {}
+    },
+    {
+        "DisplayName": "Additional Flags Arguments",
+        "Category": "Killing Floor 2:stadia_controller",
+        "Subcategory": "Server:dns:1",
+        "Description": "Specify additional [command-line flags](https://wiki.killingfloor2.com/index.php?title=Dedicated_Server_(Killing_Floor_2%29). Example: -NoSteamClient -SomeOtherFlag. Don't use flags already in AMP's settings!",
+        "Keywords": "custom,flags,arguments,flags",
+        "FieldName": "CustomFlags",
+        "InputType": "text",
+        "ParamFieldName": "CustomFlags",
         "DefaultValue": "",
         "EnumValues": {}
     }

--- a/killing-floor-2config.json
+++ b/killing-floor-2config.json
@@ -267,5 +267,17 @@
         "IncludeInCommandLine": false,
         "DefaultValue": "https://cubecoders.com/AMP",
         "EnumValues": {}
+    },
+    {
+        "DisplayName": "Additional Command Line Arguments",
+        "Category": "Killing Floor 2:stadia_controller",
+        "Subcategory": "Server:dns:1",
+        "Description": "Specify additional startup arguments in URL format (e.g., ?Mutator=KFMutator.YourMutator). Use with care.",
+        "Keywords": "custom,server,arguments,parameters",
+        "FieldName": "CustomArgs",
+        "InputType": "text",
+        "ParamFieldName": "CustomArgs",
+        "DefaultValue": "",
+        "EnumValues": {}
     }
 ]

--- a/killing-floor-2config.json
+++ b/killing-floor-2config.json
@@ -272,7 +272,7 @@
         "DisplayName": "Additional Command Line Arguments",
         "Category": "Killing Floor 2:stadia_controller",
         "Subcategory": "Server:dns:1",
-        "Description": "Specify additional startup arguments in URL format (e.g., ?Mutator=KFMutator.YourMutator). Use with care.",
+        "Description": "Specify additional startup arguments to be injected between the URL-style variables and the dash-prefixed command-line flags. Ordering is important: URL-style arguments (e.g., ?Mutator=KFMutator.YourMutator) must come first, followed by any dash-style flags (e.g., -NoSteamClient). Example: ?AdminPassword=123?Mutator=KFMutator.MyMutator -NoSteamClient",
         "Keywords": "custom,server,arguments,parameters",
         "FieldName": "CustomArgs",
         "InputType": "text",


### PR DESCRIPTION
## Description

This PR adds to the KF2 configuration additional startup arguments: `CustomUrlArgs` and `CustomFlags`.
## Changes

- Added `CustomUrlArgs` for URL-style parameters (e.g., `?Mutator=KFMutator.MyMutator`).
- Added `CustomFlags` for dash-prefixed flags (e.g., `-NoSteamClient`).
- Ensures AMP-defined flags always take precedence over user-defined ones.
- Improves flexibility and compatibility with mods, mutators, or other custom server configurations.
