### PR TITLE
Update seven-days-to-dieconfig.json

### DIFF
--- a/seven-days-to-dieconfig.json
+++ b/seven-days-to-dieconfig.json
@@ -1500,7 +1500,6 @@
             "v1.3": "Version 1.3",
             "v1.2": "Version 1.2",
             "v1.1": "Version 1.1",
-            "v1.0": "Version 1.0",
             "alpha21.2": "Alpha 21.2",
             "alpha21.1": "Alpha 21.1",
             "alpha20.7": "Alpha 20.7",


### PR DESCRIPTION
v1.0 is no longer provided by Steam.