### PR TITLE
Alien Swarm: Reactive Drop: deprecate

### DIFF
--- a/alien-swarm-reactive-drop.kvp
+++ b/alien-swarm-reactive-drop.kvp
@@ -1,6 +1,6 @@
 Meta.DisplayName=Alien Swarm: Reactive Drop
 Meta.Description=Alien Swarm: Reactive Drop Dedicated Server
-Meta.OS=Windows, Linux
+Meta.OS=
 Meta.AarchSupport=NotSupported
 Meta.Arch=x86_64
 Meta.Author=Greelan


### PR DESCRIPTION
It doesn't obey source tv and client ports bindings, either on Linux or Windows