### PR TITLE
SOTF: enable skipping network test by default

### DIFF
--- a/sons-of-the-forestconfig.json
+++ b/sons-of-the-forestconfig.json
@@ -295,7 +295,7 @@
         "IsFlagArgument": false,
         "ParamFieldName": "$.SkipNetworkAccessibilityTest",
         "IncludeInCommandLine": false,
-        "DefaultValue": "false",
+        "DefaultValue": "true",
         "EnumValues": {
             "True": "true",
             "False": "false"


### PR DESCRIPTION
Seems to cause more issues than it solves