### PR TITLE
Update path-of-titans.kvp Regex patterns

### DIFF
--- a/path-of-titans.kvp
+++ b/path-of-titans.kvp
@@ -93,8 +93,8 @@ Console.FilterMatchRegex=
 Console.FilterMatchReplacement=
 Console.ThrowawayMessageRegex=^(WARNING|ERROR): Shader.+$
 Console.AppReadyRegex=^(?:\[[\d\.]+-[\d\.:]+\]\[[\d ]+\])?LogGameMode: Display: Match State Changed from WaitingToStart to InProgress$
-Console.UserJoinRegex=^(?:\[[\d\.]+-[\d\.:]+\]\[[\d ]+\])?TitansNetwork: AIGameMode::InitNewPlayer\(\?EncryptionToken=(?:.+?)==\?Name=(?<username>.+?)\?\?PID=(?<userid>.+?)\?PT=\d+\?OS=\d+\?SplitscreenCount=\d+\)$
-Console.UserLeaveRegex=^(?:\[[\d\.]+-[\d\.:]+\]\[[\d ]+\])?AlderonLog: IAlderonCommon:UnregisterPlayer\(\) Request: {"player_id":(?<userid>.+?),"platform":"(?:.+?)"(?:.*?)}$
+Console.UserJoinRegex=^(?:\[[\d\.]+-[\d\.:]+\]\[[\d ]+\])?LogBattlEyeServer\:\sPlayer\s\#\d+\s(?<username>.+?)\s\((?<endpoint>[\d\.]+)\:\d*\)\sconnected
+Console.UserLeaveRegex=^(?:\[[\d\.]+-[\d\.:]+\]\[[\d ]+\])?LogBattlEyeServer\:\sPlayer\s\#\d+\s(?<username>.+?)\sdisconnected
 Console.UserChatRegex=^(?:\[[\d\.]+-[\d\.:]+\]\[[\d ]+\])?TitansOnline: Chat: \[(?:.+?)\] (?<username>.+?) \((?:.+?)\): (?<message>.+)$
 Console.UpdateAvailableRegex=^\[\d\d:\d\d:\d\d\] \[INFO\] A new server update is available! v[\d\.]+.$
 Console.MetricsRegex=


### PR DESCRIPTION
## Path of Titans Regex Patterns

Path of Titans console lines have changes in recent versions requiring an update to the regex patterns for users joining and leaving. This should also fix the geo analytics as the *endpoint* value can be captured when the user joins.

New console lines when a player joins:
```
[2025.06.09-20.47.40:401][795]TitansNetwork: AIGameSession::OnServerOTPGenerated: Otp: [Redacted] Token: [Redacted] PlayerId: 121-121-121
[2025.06.09-20.47.40:401][795]AlderonLog: IAlderonAuth:ServerOTPAdditionalInfo(https://alderongames.com/api/server-query/me?skinny) Token: [REDACTED] X-Alderon-Token: 
[2025.06.09-20.47.40:401][795]TitansNetwork: IGameMode::SetupDatabase()
[2025.06.09-20.47.40:401][795]LogBattlEyeServer: [RegisterClient] PlayerName: DougyX (121-121-121) alderon (Index: 0) - bHeadless 1
[2025.06.09-20.47.40:401][795]LogBattlEyeServer: Player #0 DougyX (123.123.123.123:19595) connected
[2025.06.09-20.47.40:401][795]LogBattlEyeServer: Player #0 DougyX - BE GUID: 4e8d54e8d54e8d54e8d54e8d54e8d5
[2025.06.09-20.47.40:401][795]LogBattlEyeServer: Verified GUID (4e8d54e8d54e8d54e8d54e8d54e8d5) of player #0 DougyX
[2025.06.09-20.47.40:441][797]TitansLog: IGameMode:LoadCharacter_Stage1: Deserializing 5 Characters for Player DougyX (121-121-121)
```

New console lines when a player leaves:
```
[2025.06.09-20.48.34:265][989]AlderonLog: IAlderonCommon:UnregisterPlayer() Request: {"player_id":121121121121121,"platform":"ios"}
[2025.06.09-20.48.34:265][989]LogBattlEyeServer: Player #0 DougyX disconnected
```