### PR TITLE
Update Path Of Titans user join Regex

### DIFF
--- a/path-of-titans.kvp
+++ b/path-of-titans.kvp
@@ -93,7 +93,7 @@ Console.FilterMatchRegex=
 Console.FilterMatchReplacement=
 Console.ThrowawayMessageRegex=^(WARNING|ERROR): Shader.+$
 Console.AppReadyRegex=^(?:\[[\d\.]+-[\d\.:]+\]\[[\d ]+\])?LogGameMode: Display: Match State Changed from WaitingToStart to InProgress$
-Console.UserJoinRegex=^(?:\[[\d\.]+-[\d\.:]+\]\[[\d ]+\])?TitansNetwork: AIGameMode::InitNewPlayer\(\?EncryptionToken=(?:.+?)==\?Name=(?<username>.+?)\?\?PID=(?<userid>.+?)\?PT=\d+\?OS=\d+\?SplitscreenCount=\d+\)$
+Console.UserJoinRegex=^(?:\[[\d\.]+-[\d\.:]+\]\[[\d ]+\])?AlderonLog: IAlderonCommon:RegisterPlayer\(\) Request\: \{\"player_id\"\:(?<userid>\d+),"platform":"(?:.+?)"(?:.*?)}$
 Console.UserLeaveRegex=^(?:\[[\d\.]+-[\d\.:]+\]\[[\d ]+\])?AlderonLog: IAlderonCommon:UnregisterPlayer\(\) Request: {"player_id":(?<userid>.+?),"platform":"(?:.+?)"(?:.*?)}$
 Console.UserChatRegex=^(?:\[[\d\.]+-[\d\.:]+\]\[[\d ]+\])?TitansOnline: Chat: \[(?:.+?)\] (?<username>.+?) \((?:.+?)\): (?<message>.+)$
 Console.UpdateAvailableRegex=^\[\d\d:\d\d:\d\d\] \[INFO\] A new server update is available! v[\d\.]+.$


### PR DESCRIPTION
## POT User Join regex match

Attempted to find a line that has the username, endpoint for a nicer experience but it wasn't aligning to when a user would leave or Battle eye was disabled. Safest line is the closest to the existing user leaving regex.

I have tested and this line doesn't appear when a user is blocked from the server.

Sample user joining line:
```
[2025.06.13-00.10.37:526][999]AlderonLog: IAlderonCommon:RegisterPlayer() Request: {"player_id":121364849,"platform":"windows"}
```
