### PR TITLE
Minecraft Bedrock: updating server download stages

### DIFF
--- a/minecraft-bedrockupdates.json
+++ b/minecraft-bedrockupdates.json
@@ -26,9 +26,9 @@
         "UpdateSourceTarget": "{{$FullBaseDir}}",
         "UnzipUpdateSource": true,
         "OverwriteExistingFiles": true,
+        "DeleteAfterExtract": true,
         "UpdateSourceConditionSetting": "ServerStream",
-        "UpdateSourceConditionValue": "release-latest",
-        "DeleteAfterExtract": true
+        "UpdateSourceConditionValue": "release-latest"
     },
     {
         "UpdateStageName": "Server Download",
@@ -39,9 +39,9 @@
         "UpdateSourceTarget": "{{$FullBaseDir}}",
         "UnzipUpdateSource": true,
         "OverwriteExistingFiles": true,
+        "DeleteAfterExtract": true,
         "UpdateSourceConditionSetting": "ServerStream",
-        "UpdateSourceConditionValue": "release-latest",
-        "DeleteAfterExtract": true
+        "UpdateSourceConditionValue": "release-latest"
     },
     {
         "UpdateStageName": "Server Download",
@@ -52,9 +52,9 @@
         "UpdateSourceTarget": "{{$FullBaseDir}}",
         "UnzipUpdateSource": true,
         "OverwriteExistingFiles": true,
+        "DeleteAfterExtract": true,
         "UpdateSourceConditionSetting": "ServerStream",
-        "UpdateSourceConditionValue": "preview-latest",
-        "DeleteAfterExtract": true
+        "UpdateSourceConditionValue": "preview-latest"
     },
     {
         "UpdateStageName": "Server Download",
@@ -65,9 +65,9 @@
         "UpdateSourceTarget": "{{$FullBaseDir}}",
         "UnzipUpdateSource": true,
         "OverwriteExistingFiles": true,
+        "DeleteAfterExtract": true,
         "UpdateSourceConditionSetting": "ServerStream",
-        "UpdateSourceConditionValue": "preview-latest",
-        "DeleteAfterExtract": true
+        "UpdateSourceConditionValue": "preview-latest"
     },
     {
         "UpdateStageName": "Server Download",

--- a/minecraft-bedrockupdates.json
+++ b/minecraft-bedrockupdates.json
@@ -20,64 +20,54 @@
     {
         "UpdateStageName": "Server Download",
         "UpdateSourcePlatform": "Windows",
-        "UpdateSource": "Executable",
-        "UpdateSourceData": "powershell.exe",
-        "UpdateSourceArgs": "-NoProfile -Command \"$ProgressPreference='SilentlyContinue'; $DOWNLOAD_URL=((Invoke-WebRequest -UseBasicParsing -Uri 'https://www.minecraft.net/en-us/download/server/bedrock' -TimeoutSec 15).Links | ? class -match 'btn' | ? href -match 'bin-win/bedrock-server' | select -ExpandProperty href); if (-not $DOWNLOAD_URL -or $DOWNLOAD_URL -eq '') { $DOWNLOAD_URL=((Invoke-WebRequest -UseBasicParsing -Uri 'https://raw.githubusercontent.com/CubeCoders/AMPTemplates/main/minecraft-bedrockdownloadurl.json').Content | ConvertFrom-Json).Release.Windows }; Invoke-WebRequest -UseBasicParsing -Uri $DOWNLOAD_URL -OutFile 'bedrock_server.zip'\"",
+        "UpdateSource": "FetchURLFromJQ",
+        "UpdateSourceData": "https://raw.githubusercontent.com/CubeCoders/AMPTemplates/main/minecraft-bedrockdownloadurl.json",
+        "UpdateSourceArgs": "$.Release.Windows",
+        "UpdateSourceTarget": "{{$FullBaseDir}}",
+        "UnzipUpdateSource": true,
+        "OverwriteExistingFiles": true,
         "UpdateSourceConditionSetting": "ServerStream",
         "UpdateSourceConditionValue": "release-latest",
-        "SkipOnFailure": false
-    },
-    {
-        "UpdateStageName": "Server Extract",
-        "UpdateSourcePlatform": "Windows",
-        "UpdateSource": "ExtractArchive",
-        "UpdateSourceData": "bedrock_server.zip",
-        "UpdateSourceTarget": "{{$FullBaseDir}}",
-        "OverwriteExistingFiles": true,
-        "DeleteAfterExtract": true,
-        "UpdateSourceConditionSetting": "ServerStream",
-        "UpdateSourceConditionValue": "release-latest"
+        "DeleteAfterExtract": true
     },
     {
         "UpdateStageName": "Server Download",
         "UpdateSourcePlatform": "Linux",
-        "UpdateSource": "Executable",
-        "UpdateSourceData": "/bin/bash",
-        "UpdateSourceArgs": "-c \"cd Minecraft && DOWNLOAD_URL=$(timeout 15s wget -qO- --user-agent=\\\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.$((1 + RANDOM % 4000)).212 Safari/537.36\\\" https://www.minecraft.net/en-us/download/server/bedrock | grep -o \\\"https://[^\\\\\\\"]*/bin-linux/bedrock-server-[^\\\\\\\"]*\\\"); [[ -z $DOWNLOAD_URL || ! -n $DOWNLOAD_URL ]] && DOWNLOAD_URL=$(wget -qO- https://raw.githubusercontent.com/CubeCoders/AMPTemplates/main/minecraft-bedrockdownloadurl.json | jq -r \\\".Release.Linux\\\"); wget -qO bedrock_server.zip --user-agent=\\\"CubeCoders/AMP_DLM\\\" $DOWNLOAD_URL && unzip -qo bedrock_server.zip && rm -rf bedrock_server.zip\"",
+        "UpdateSource": "FetchURLFromJQ",
+        "UpdateSourceData": "https://raw.githubusercontent.com/CubeCoders/AMPTemplates/main/minecraft-bedrockdownloadurl.json",
+        "UpdateSourceArgs": "$.Release.Linux",
+        "UpdateSourceTarget": "{{$FullBaseDir}}",
+        "UnzipUpdateSource": true,
+        "OverwriteExistingFiles": true,
         "UpdateSourceConditionSetting": "ServerStream",
         "UpdateSourceConditionValue": "release-latest",
-        "SkipOnFailure": false
+        "DeleteAfterExtract": true
     },
     {
         "UpdateStageName": "Server Download",
         "UpdateSourcePlatform": "Windows",
-        "UpdateSource": "Executable",
-        "UpdateSourceData": "powershell.exe",
-        "UpdateSourceArgs": "-NoProfile -Command \"$ProgressPreference='SilentlyContinue'; $DOWNLOAD_URL=((Invoke-WebRequest -UseBasicParsing -Uri 'https://www.minecraft.net/en-us/download/server/bedrock' -TimeoutSec 15).Links | ? class -match 'btn' | ? href -match 'bin-win-preview/bedrock-server' | select -ExpandProperty href); if (-not $DOWNLOAD_URL -or $DOWNLOAD_URL -eq '') { $DOWNLOAD_URL=((Invoke-WebRequest -UseBasicParsing -Uri 'https://raw.githubusercontent.com/CubeCoders/AMPTemplates/main/minecraft-bedrockdownloadurl.json').Content | ConvertFrom-Json).Preview.Windows }; Invoke-WebRequest -UseBasicParsing -Uri $DOWNLOAD_URL -OutFile 'bedrock_server.zip'\"",
+        "UpdateSource": "FetchURLFromJQ",
+        "UpdateSourceData": "https://raw.githubusercontent.com/CubeCoders/AMPTemplates/main/minecraft-bedrockdownloadurl.json",
+        "UpdateSourceArgs": "$.Preview.Windows",
+        "UpdateSourceTarget": "{{$FullBaseDir}}",
+        "UnzipUpdateSource": true,
+        "OverwriteExistingFiles": true,
         "UpdateSourceConditionSetting": "ServerStream",
         "UpdateSourceConditionValue": "preview-latest",
-        "SkipOnFailure": false
-    },
-    {
-        "UpdateStageName": "Server Extract",
-        "UpdateSourcePlatform": "Windows",
-        "UpdateSource": "ExtractArchive",
-        "UpdateSourceData": "bedrock_server.zip",
-        "UpdateSourceTarget": "{{$FullBaseDir}}",
-        "OverwriteExistingFiles": true,
-        "DeleteAfterExtract": true,
-        "UpdateSourceConditionSetting": "ServerStream",
-        "UpdateSourceConditionValue": "preview-latest"
+        "DeleteAfterExtract": true
     },
     {
         "UpdateStageName": "Server Download",
         "UpdateSourcePlatform": "Linux",
-        "UpdateSource": "Executable",
-        "UpdateSourceData": "/bin/bash",
-        "UpdateSourceArgs": "-c \"cd Minecraft && DOWNLOAD_URL=$(timeout 15s wget -qO- --user-agent=\\\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.$((1 + RANDOM % 4000)).212 Safari/537.36\\\" https://www.minecraft.net/en-us/download/server/bedrock | grep -o \\\"https://[^\\\\\\\"]*/bin-linux-preview/bedrock-server-[^\\\\\\\"]*\\\") [[ -z $DOWNLOAD_URL || ! -n $DOWNLOAD_URL ]] && DOWNLOAD_URL=$(wget -qO- https://raw.githubusercontent.com/CubeCoders/AMPTemplates/main/minecraft-bedrockdownloadurl.json | jq -r \\\".Preview.Linux\\\"); wget -qO bedrock_server.zip --user-agent=\\\"CubeCoders/AMP_DLM\\\" $DOWNLOAD_URL && unzip -qo bedrock_server.zip && rm -rf bedrock_server.zip\"",
+        "UpdateSource": "FetchURLFromJQ",
+        "UpdateSourceData": "https://raw.githubusercontent.com/CubeCoders/AMPTemplates/main/minecraft-bedrockdownloadurl.json",
+        "UpdateSourceArgs": "$.Preview.Linux",
+        "UpdateSourceTarget": "{{$FullBaseDir}}",
+        "UnzipUpdateSource": true,
+        "OverwriteExistingFiles": true,
         "UpdateSourceConditionSetting": "ServerStream",
         "UpdateSourceConditionValue": "preview-latest",
-        "SkipOnFailure": false
+        "DeleteAfterExtract": true
     },
     {
         "UpdateStageName": "Server Download",


### PR DESCRIPTION
MS has made website scraping even harder. The data source in the AMP repo is now the only reliable way