### PR TITLE
7DTD: add logging argument

### DIFF
--- a/seven-days-to-die.kvp
+++ b/seven-days-to-die.kvp
@@ -35,7 +35,7 @@ App.ExecutableLinux=294420/7DaysToDieServer.x86_64
 App.WorkingDir=294420
 App.LinuxCommandLineArgs=
 App.WindowsCommandLineArgs=
-App.CommandLineArgs=-quit -batchmode -nographics -dedicated -configfile=serverconfig.xml -UserDataFolder=User {{ModMode}}{{$FormattedArgs}}
+App.CommandLineArgs=-logFile -quit -batchmode -nographics -dedicated -configfile=serverconfig.xml -UserDataFolder=User {{ModMode}}{{$FormattedArgs}}
 App.UseLinuxIOREDIR=False
 App.AppSettings={}
 App.EnvironmentVariables={"DOORSTOP_ENABLE":"TRUE","DOORSTOP_INVOKE_DLL_PATH":"./BepInEx/core/BepInEx.Preloader.dll","DOORSTOP_CORLIB_OVERRIDE_PATH":"./BepInEx/core","LD_LIBRARY_PATH":".:./doorstop_libs:{{$FullBaseDir}}linux64:{{$FullRootDir}}linux64:%LD_LIBRARY_PATH%","LD_PRELOAD":"libdoorstop_x64.so","SteamAppId":"251570"}


### PR DESCRIPTION
This should ensure that the logging captured in AMP's logs is the equivalent of what the server would otherwise write to a timestamped file (aside from the filtering of shader warnings/errors). Middle ground until proper log tailing is introduced in AMP