### PR TITLE
Update v-risingconfig.json to fix LanMode flag

### DIFF
--- a/v-risingconfig.json
+++ b/v-risingconfig.json
@@ -2134,13 +2134,13 @@
         "Keywords": "lan,mode",
         "FieldName": "LanMode",
         "InputType": "checkbox",
-        "DefaultValue": "",
+        "DefaultValue": "false",
         "IsFlagArgument": false,
         "ParamFieldName": "LanMode",
         "IncludeInCommandLine": false,
         "EnumValues": {
-            "False": "",
-            "True": "-lan"
+            "False": "false",
+            "True": "true"
         }
     },
     {


### PR DESCRIPTION
The LanMode flag should correctly be added to the ServerHostSettings.json with a value of true or false.