### PR TITLE
Ark Survival Ascended: allow alternate public ips

### DIFF
--- a/ark-sa-min.kvp
+++ b/ark-sa-min.kvp
@@ -21,7 +21,7 @@ Meta.Prerequisites=[]
 Meta.ExtraContainerPackages=["pciutils"]
 Meta.ConfigReleaseState=NotSpecified
 Meta.NoCommercialUsage=False
-Meta.ConfigVersion=8
+Meta.ConfigVersion=9
 Meta.ReleaseNotes=
 Meta.BreakingReleaseNotes=
 Meta.AppConfigId=03e2b339-49b5-428f-9cfb-6161684e6653
@@ -35,7 +35,7 @@ App.ExecutableLinux=.proton/proton
 App.WorkingDir=2430930/ShooterGame/Binaries/Win64
 App.LinuxCommandLineArgs=runinprefix "{{$FullBaseDir}}ShooterGame/Binaries/Win64/{{ServerExecutable}}.exe"
 App.WindowsCommandLineArgs=
-App.CommandLineArgs={{$PlatformArgs}} {{Map}}?listen?Port={{$GamePort}}?RCONEnabled=True?RCONServerGameLogBuffer=600?RCONPort={{$RCONPort}}{{CustomOptions}}?ServerAdminPassword={{$RemoteAdminPassword}} -WinLiveMaxPlayers={{$MaxUsers}} {{passivemods}}{{mods}}{{pconlymods}}{{Colors}}{{exclusivejoin}}{{BattlEye}}{{usestore}}-ServerPlatform={{ServerPlatform}} {{UseDynamicConfig}}{{EnableIdlePlayerKick}}{{NoHangDetection}}{{DisableCustomCosmetics}}{{NoTransferFromFiltering}}{{ForceAllowCaveFlyers}}{{nodinos}}{{ForceRespawnDinos}}{{DisableRailgunPVP}}{{UseStructureStasisGrid}}-culture={{culture}} {{EnableCluster}}{{CustomFlags}} -servergamelog
+App.CommandLineArgs={{$PlatformArgs}} {{Map}}?listen?Port={{$GamePort}}?RCONEnabled=True?RCONServerGameLogBuffer=600?RCONPort={{$RCONPort}}{{CustomOptions}}?ServerAdminPassword={{$RemoteAdminPassword}} -WinLiveMaxPlayers={{$MaxUsers}} {{passivemods}}{{mods}}{{pconlymods}}{{Colors}}{{exclusivejoin}}{{BattlEye}}{{usestore}}-ServerPlatform={{ServerPlatform}} {{UseDynamicConfig}}{{EnableIdlePlayerKick}}{{NoHangDetection}}{{DisableCustomCosmetics}}{{NoTransferFromFiltering}}{{ForceAllowCaveFlyers}}{{nodinos}}{{ForceRespawnDinos}}{{DisableRailgunPVP}}{{UseStructureStasisGrid}}-culture={{culture}} {{EnableCluster}}{{ServerIP}}{{CustomFlags}} -servergamelog
 App.UseLinuxIOREDIR=False
 App.AppSettings={}
 App.EnvironmentVariables={"SteamAppId":"2399830","STEAM_COMPAT_DATA_PATH":"{{$FullRootDir}}.proton/compatdata","STEAM_COMPAT_CLIENT_INSTALL_PATH":"{{$FullBaseDir}}.steam/steam","HOME":"{{$FullBaseDir}}","XDG_RUNTIME_DIR":"/tmp"}

--- a/ark-sa-minconfig.json
+++ b/ark-sa-minconfig.json
@@ -334,6 +334,33 @@
         }
     },
     {
+        "DisplayName": "Public IP Selection Mode",
+        "Category": "ARK SA:stadia_controller",
+        "Subcategory": "Server:dns:1",
+        "Description": "Sets whether ARK should automatically select the public IP advertised for the server, or whether it should use the IP set under Server Public IP",
+        "Keywords": "public,ip,ServerIP",
+        "FieldName": "ServerIP",
+        "InputType": "enum",
+        "ParamFieldName": "ServerIP",
+        "DefaultValue": "",
+        "EnumValues": {
+            "": "Automatic (default)",
+            "-ServerIP={{ManualServerIP}} ": "Manual"
+        }
+    },
+    {
+        "DisplayName": "Server Public IP",
+        "Category": "ARK SA:stadia_controller",
+        "Subcategory": "Server:dns:1",
+        "Description": "Sets the public IP advertised for the server, if \"Manual\" is selected as the Public IP Selection Mode. Useful if the host network has multiple public IPs, or the server is behind a public proxy",
+        "Keywords": "manual,public,ip,serverip",
+        "FieldName": "ManualServerIP",
+        "InputType": "text",
+        "ParamFieldName": "ManualServerIP",
+        "DefaultValue": "",
+        "EnumValues": {}
+    },
+    {
         "DisplayName": "Custom Command Line Flags",
         "Category": "ARK SA:stadia_controller",
         "Subcategory": "Server:dns:1",

--- a/ark-sa.kvp
+++ b/ark-sa.kvp
@@ -21,7 +21,7 @@ Meta.Prerequisites=[]
 Meta.ExtraContainerPackages=["pciutils"]
 Meta.ConfigReleaseState=NotSpecified
 Meta.NoCommercialUsage=False
-Meta.ConfigVersion=12
+Meta.ConfigVersion=13
 Meta.ReleaseNotes=
 Meta.BreakingReleaseNotes=
 Meta.AppConfigId=218120ac-08ee-466e-9f60-5ba605436e11
@@ -35,7 +35,7 @@ App.ExecutableLinux=.proton/proton
 App.WorkingDir=2430930/ShooterGame/Binaries/Win64
 App.LinuxCommandLineArgs=runinprefix "{{$FullBaseDir}}ShooterGame/Binaries/Win64/{{ServerExecutable}}.exe"
 App.WindowsCommandLineArgs=
-App.CommandLineArgs={{$PlatformArgs}} {{Map}}?listen?Port={{$GamePort}}?RCONEnabled=True?RCONServerGameLogBuffer=600?RCONPort={{$RCONPort}}?{{$FormattedArgs}}{{OverrideOfficialDifficulty}}{{CustomOptions}}?ServerAdminPassword={{$RemoteAdminPassword}} -WinLiveMaxPlayers={{$MaxUsers}} {{passivemods}}{{mods}}{{pconlymods}}{{Colors}}{{exclusivejoin}}{{BattlEye}}{{usestore}}-ServerPlatform={{ServerPlatform}} {{EnableIdlePlayerKick}}{{NoHangDetection}}{{NoTransferFromFiltering}}{{AllowSpeedLeveling}}{{ForceAllowCaveFlyers}}{{nodinos}}{{ForceRespawnDinos}}{{DisableRailgunPVP}}{{UseStructureStasisGrid}}-culture={{culture}} {{EnableCluster}}{{CustomFlags}} {{UseAlternatePublicIP}} -servergamelog
+App.CommandLineArgs={{$PlatformArgs}} {{Map}}?listen?Port={{$GamePort}}?RCONEnabled=True?RCONServerGameLogBuffer=600?RCONPort={{$RCONPort}}?{{$FormattedArgs}}{{OverrideOfficialDifficulty}}{{CustomOptions}}?ServerAdminPassword={{$RemoteAdminPassword}} -WinLiveMaxPlayers={{$MaxUsers}} {{passivemods}}{{mods}}{{pconlymods}}{{Colors}}{{exclusivejoin}}{{BattlEye}}{{usestore}}-ServerPlatform={{ServerPlatform}} {{EnableIdlePlayerKick}}{{NoHangDetection}}{{NoTransferFromFiltering}}{{AllowSpeedLeveling}}{{ForceAllowCaveFlyers}}{{nodinos}}{{ForceRespawnDinos}}{{DisableRailgunPVP}}{{UseStructureStasisGrid}}-culture={{culture}} {{EnableCluster}}{{ServerIP}}{{CustomFlags}} -servergamelog
 App.UseLinuxIOREDIR=False
 App.AppSettings={}
 App.EnvironmentVariables={"SteamAppId":"2399830","STEAM_COMPAT_DATA_PATH":"{{$FullRootDir}}.proton/compatdata","STEAM_COMPAT_CLIENT_INSTALL_PATH":"{{$FullBaseDir}}.steam/steam","HOME":"{{$FullBaseDir}}","XDG_RUNTIME_DIR":"/tmp"}

--- a/ark-saconfig.json
+++ b/ark-saconfig.json
@@ -418,6 +418,33 @@
         }
     },
     {
+        "DisplayName": "Public IP Selection Mode",
+        "Category": "ARK SA:stadia_controller",
+        "Subcategory": "Server:dns:1",
+        "Description": "Sets whether ARK should automatically select the public IP advertised for the server, or whether it should use the IP set under Server Public IP",
+        "Keywords": "public,ip,ServerIP",
+        "FieldName": "ServerIP",
+        "InputType": "enum",
+        "ParamFieldName": "ServerIP",
+        "DefaultValue": "",
+        "EnumValues": {
+            "": "Automatic (default)",
+            "-ServerIP={{ManualServerIP}} ": "Manual"
+        }
+    },
+    {
+        "DisplayName": "Server Public IP",
+        "Category": "ARK SA:stadia_controller",
+        "Subcategory": "Server:dns:1",
+        "Description": "Sets the public IP advertised for the server, if \"Manual\" is selected as the Public IP Selection Mode. Useful if the host network has multiple public IPs, or the server is behind a public proxy",
+        "Keywords": "manual,public,ip,serverip",
+        "FieldName": "ManualServerIP",
+        "InputType": "text",
+        "ParamFieldName": "ManualServerIP",
+        "DefaultValue": "",
+        "EnumValues": {}
+    },
+    {
         "DisplayName": "Custom Command Line Flags",
         "Category": "ARK SA:stadia_controller",
         "Subcategory": "Server:dns:1",
@@ -441,35 +468,6 @@
         "ParamFieldName": "CustomOptions",
         "DefaultValue": "",
         "Placeholder": "?ClampItemStats=True?NewYear1UTC=1672592400",
-        "EnumValues": {}
-    },
-    {
-        "DisplayName": "Use Alternate Public IP",
-        "Category": "ARK SA:stadia_controller",
-        "Subcategory": "Server:dns:1",
-        "Description": "Enables the Alternate Public IP option for the server",
-        "Keywords": "alternate,public,ip,address",
-        "FieldName": "UseAlternatePublicIP",
-        "InputType": "checkbox",
-        "ParamFieldName": "UseAlternatePublicIP",
-        "DefaultValue": "",
-        "EnumValues": {
-            "False": "",
-            "True": "-ServerIP={{ServerIP}}"
-        }
-    },
-    {
-        "DisplayName": "Alternate Public IP",
-        "Category": "ARK SA:stadia_controller",
-        "Subcategory": "Server:dns:1",
-        "Description": "If the server is behind a NAT or firewall, set the public IP address here to allow it to be accessed correctly",
-        "Keywords": "alternate,public,ip,address",
-        "FieldName": "ServerIP",
-        "InputType": "text",
-        "ParamFieldName": "ServerIP",
-        "DefaultValue": "",
-        "IncludeInCommandLine": false,
-        "Placeholder": "0.0.0.0",
         "EnumValues": {}
     },
     {


### PR DESCRIPTION
Ark: Survival Ascended moved away from using the Steam Query Port to an ingame server browser.

The disadvange to this is that servers running behind a proxy, or under a tight NAT, are unable to specify the public ip that they want to connect with. The -ServerIP flag allows you to specify exactly that, and allows the server browser to send the connection to the proper ip. _As of this time, the -ServerIP flag remains undocumented by Studio Wildcard, and is primarily used by Nitrado_

This is my first time writing a change to an AMP Config, I did this personally with a custom flag, but it felt useful to just have as a simple config, considering the switch.