### PR TITLE
Space Engineers: Fix issue with remote API config

### DIFF
--- a/space-engineers-dedicated.cfg
+++ b/space-engineers-dedicated.cfg
@@ -217,7 +217,6 @@
   <RemoteApiEnabled>true</RemoteApiEnabled>
   <RemoteSecurityKey />
   <RemoteApiPort>8080</RemoteApiPort>
-  <RemoteApiIP>0.0.0.0</RemoteApiIP>
   <Plugins />
   <WatcherInterval>30</WatcherInterval>
   <WatcherSimulationSpeedMinimum>0.05</WatcherSimulationSpeedMinimum>


### PR DESCRIPTION
This removes the setting for `RemoteApiIP` from the Space Engineers dedicated server configuration. I had found that having the option set was preventing the remote API from working at all. I had been trying to use it for the Prometheus exporter to monitor the server, but found anything that called to the API was hanging on reading a response and eventually gave up.

Then I was doing some experimenting with a config from an old server and found that the remote API was working. Through a process of elimination looking at system packages, Wine configuration, Docker, everything, I found all I had to do to my AMP instance was to remove this line and it worked. I am not sure how it affects the game internally, but it started working fine in AMP and out of AMP with the setting removed.

One way to test and verify is that if you enable the remote API and configure it, you can do a simple curl command:

```
curl -v <machine-ip>:8777/vrageremote/v1/session/players
```

With the `RemoteApiIP` setting in, the request will hang. You can see it sent the request, but it hangs on getting a response. You'll probably also note that on the instance status page, AMP won't show the remote API port as listening.

Without the `RemoteApiIP`, you should get a `403 Forbidden` back and see a log message in game about unauthorized call.