### PR TITLE
Change game port from 7777 to 8777

### DIFF
--- a/astroneerports.json
+++ b/astroneerports.json
@@ -1,7 +1,7 @@
 [
     {
         "Protocol": "UDP",
-        "Port": 7777,
+        "Port": 8777,
         "Ref": "ApplicationPort1",
         "Name": "Game Port",
         "Description": "Port for game traffic"


### PR DESCRIPTION
The official Astroneer site calls out that dedicated servers need to run on Port 8777, more information can be found here https://blog.astroneer.space/p/astroneer-dedicated-server-details/

I was not able to get the server running myself until I made this correction myself on my own AMP game server. This will help majorly with a ton of people running into these issues as stated in the Astroneer Discord server.

<img width="973" height="796" alt="image" src="https://github.com/user-attachments/assets/ed722de8-cb29-45d7-a461-73951180d456" />