### PR TITLE
Conan Exiles: switch template to legacy

### DIFF
--- a/conan-exiles.kvp
+++ b/conan-exiles.kvp
@@ -1,5 +1,5 @@
-Meta.DisplayName=Conan Exiles
-Meta.Description=Conan Exiles Dedicated Server
+Meta.DisplayName=Conan Exiles (Legacy)
+Meta.Description=Conan Exiles Legacy UE4 Dedicated Server
 Meta.OS=Windows, Linux
 Meta.AarchSupport=NotSupported
 Meta.Arch=x86_64
@@ -20,7 +20,7 @@ Meta.Prerequisites=[]
 Meta.ExtraContainerPackages=[]
 Meta.ConfigReleaseState=NotSpecified
 Meta.NoCommercialUsage=False
-Meta.ConfigVersion=5
+Meta.ConfigVersion=6
 Meta.AppConfigId=33716b55-127d-43b1-a764-f9467ee5da1f
 App.DisplayName=Conan Exiles
 App.RootDir=./conan-exiles/

--- a/conan-exilesupdates.json
+++ b/conan-exilesupdates.json
@@ -6,6 +6,7 @@
         "UpdateSourceData": "443030",
         "UpdateSourceArgs": "440900",
         "ForceDownloadPlatform": "Windows",
+        "UpdateSourceVersion": "conan-exiles-legacy",
         "SkipOnFailure": false
     },
     {


### PR DESCRIPTION
A new template will be required for the UE5 update