### PR TITLE
Astro Colony: add UnlimitedResourceStack setting

### DIFF
--- a/astro-colonyconfig.json
+++ b/astro-colonyconfig.json
@@ -153,6 +153,21 @@
         }
     },
     {
+        "DisplayName": "Enable Unlimited Resource Stack",
+        "Category": "Astro Colony:stadia_controller",
+        "Subcategory": "Server:dns:1",
+        "Description": "If enabled, resource stack sizes will be unlimited",
+        "Keywords": "unlimited,resource,stack,UnlimitedResourceStack",
+        "FieldName": "UnlimitedResourceStack",
+        "InputType": "checkbox",
+        "ParamFieldName": "UnlimitedResourceStack",
+        "DefaultValue": "False",
+        "EnumValues": {
+            "False": "False",
+            "True": "True"
+        }
+    },
+    {
         "DisplayName": "Enable Sandbox Mode",
         "Category": "Astro Colony:stadia_controller",
         "Subcategory": "Server:dns:1",

--- a/astro-colonymetaconfig.json
+++ b/astro-colonymetaconfig.json
@@ -17,6 +17,7 @@
                     "OxygenConsumption": "OxygenConsumption",
                     "FreeConstruction": "FreeConstruction",
                     "Sandbox": "Sandbox",
+                    "UnlimitedResourceStack": "UnlimitedResourceStack",
                     "AutosaveInterval": "AutosaveInterval",
                     "AutosavesCount": "AutosavesCount"
                 }
@@ -41,6 +42,7 @@
                     "OxygenConsumption": "OxygenConsumption",
                     "FreeConstruction": "FreeConstruction",
                     "Sandbox": "Sandbox",
+                    "UnlimitedResourceStack": "UnlimitedResourceStack",
                     "AutosaveInterval": "AutosaveInterval",
                     "AutosavesCount": "AutosavesCount"
                 }


### PR DESCRIPTION
## Summary
- Adds the `UnlimitedResourceStack` boolean server setting to the Astro Colony template, which was recently added to the game's server settings but is missing from this AMP template.
- Follows the existing pattern used by other boolean options (e.g. `FreeConstruction`, `Sandbox`).

## Test plan
- [x] Validated `astro-colonyconfig.json` is valid JSON
- [ ] Verify the new option appears correctly in the AMP UI and is passed through to the server as expected