### PR TITLE
Update project-zomboid.kvp

### DIFF
--- a/project-zomboid.kvp
+++ b/project-zomboid.kvp
@@ -76,7 +76,7 @@ Console.AppReadyRegex=^LOG\s+: Network\s+.*> \*+ SERVER STARTED \*+$
 Console.UserJoinRegex=^LOG\s+: (Network\s+.*> ConnectionManager: \[fully-connected\] (?:.+?) steam-id=(?<userid>.+?) (?:.+?) username="(?<username>.+?)" (?:.+?)|Multiplayer\s+.*> connection: guid=(?<userid>.+?) \[fully-connected\] "")$
 Console.UserLeaveRegex=^LOG\s+: (Network\s+.*> Disconnected player "(?<username>.+?)" (?<userid>.+?)|Multiplayer\s+.*> connection: guid=(?<userid>.+?) \[disconnect\] "receive-disconnect")$
 Console.UserChatRegex=^$
-Console.UpdateAvailableRegex=^$
+Console.UpdateAvailableRegex=^.*CheckModsNeedUpdate:\s*Mods need update\.?\s*$
 Console.MetricsRegex=
 Console.SuppressLogAtStart=False
 Console.ActivateLogRegex=


### PR DESCRIPTION
Project Zomboid: detect Workshop mod updates from console

Set Console.UpdateAvailableRegex to detect the
"CheckModsNeedUpdate: Mods need update" response.

This allows AMP to emit an update-available event when Project Zomboid detects that one or more configured Workshop mods need updating, making it possible to trigger automated restart/update workflows through the scheduler.