### PR TITLE
Update wreckfest2config.json

### DIFF
--- a/wreckfest2config.json
+++ b/wreckfest2config.json
@@ -56,7 +56,7 @@
         "FieldName": "SpecificReleaseVersion",
         "InputType": "text",
         "ParamFieldName": "SpecificReleaseVersion",
-        "DefaultValue": "",
+        "DefaultValue": "GE-Proton10-34",
         "Placeholder": "GE-Proton9-1",
         "EnumValues": {}
     }


### PR DESCRIPTION
Change Proton DefaultValue from "" to "GE-Proton10-34" At least the current version of Proton 11 downloaded it prevents the server from properly launching, not visible in game server browser nor direct connectable. No AMP logs reflecting a successful/failed server start. It does work with 10-34 when testing, still nothing shows up in AMP logs, must be a wreckfest2 thing.